### PR TITLE
feat: add par2 obfuscation policy to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ posting:
   throttle_rate: 1048576
   message_id_format: random
   obfuscation_policy: full
+  par2_obfuscation_policy: full
   group_policy: each_file
   post_headers:
     add_ngx_header: true
@@ -123,6 +124,7 @@ watcher:
   - `max_workers`: Maximum number of concurrent workers (auto-set based on server connections)
   - `message_id_format`: Format of message IDs ("random" or "ngx")
   - `obfuscation_policy`: Level of obfuscation ("full", "partial", or "none")
+  - `par2_obfuscation_policy`: Level of obfuscation for par2 files ("full", "partial", or "none")
   - `group_policy`: How to distribute posts across groups ("all" or "each_file")
   - `post_headers`: Additional headers configuration
     - `add_ngx_header`: Whether to add X-NXG header

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -28,6 +28,7 @@ posting:
   max_workers: 10 # This is automatically set based on server connections
   message_id_format: random # Options: random, ngx
   obfuscation_policy: full # Options: full, partial, none
+  par2_obfuscation_policy: full # Options: full, partial, none
   group_policy: each_file # Options: all, each_file
   post_headers:
     add_ngx_header: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,7 +146,8 @@ type PostingConfig struct {
 	MessageIDFormat    MessageIDFormat `yaml:"message_id_format"`
 	PostHeaders        PostHeaders     `yaml:"post_headers"`
 	// If true the uploaded subject and filename will be obfuscated. Default value is `true`.
-	ObfuscationPolicy ObfuscationPolicy `yaml:"obfuscation_policy"`
+	ObfuscationPolicy     ObfuscationPolicy `yaml:"obfuscation_policy"`
+	Par2ObfuscationPolicy ObfuscationPolicy `yaml:"par2_obfuscation_policy"`
 	//  If you give several Groups you've 3 policy when posting
 	GroupPolicy GroupPolicy `yaml:"group_policy"`
 }

--- a/internal/poster/poster.go
+++ b/internal/poster/poster.go
@@ -383,7 +383,12 @@ func (p *poster) addPost(filePath string, fileNumber int, totalFiles int, wg *sy
 
 		var fName string
 
-		switch p.cfg.ObfuscationPolicy {
+		obfuscationPolicy := p.cfg.ObfuscationPolicy
+		if par2.IsPar2File(filePath) {
+			obfuscationPolicy = p.cfg.Par2ObfuscationPolicy
+		}
+
+		switch obfuscationPolicy {
 		case config.ObfuscationPolicyNone:
 			fName = fileName
 		case config.ObfuscationPolicyFull:


### PR DESCRIPTION
Updated configuration files to include a new `par2_obfuscation_policy` option for enhanced obfuscation control of PAR2 files. Adjusted README and sample configuration to reflect this addition, ensuring clarity on usage and options.