### PR TITLE
feat: enhance Par2 configuration and posting logic

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -28,6 +28,10 @@ connection_pool:
   skip_providers_verification_on_creation: false
 
 posting:
+  # Wait for par2 generation before uploading the file.
+  # Setting this to false could improve the posting speed but you risk into posting
+  # a something without par2 if this fails, also it will increase the resource usage
+  wait_for_par2: true
   max_retries: 3
   retry_delay: 5s
   article_size_in_bytes: 750000
@@ -48,6 +52,7 @@ post_check:
   max_reposts: 1
 
 par2:
+  enabled: true
   par2_path: ./parpar
   redundancy: "1n*1.2" # [redundancy](https://github.com/animetosho/ParPar/blob/6feee4dd94bb18480f0bf08cd9d17ffc7e671b69/help-full.txt#L75)
   volume_size: 153600000 # 150MB
@@ -154,6 +159,7 @@ Configure PAR2 recovery file generation:
 
 ```yaml
 par2:
+  enabled: true
   par2_path: ./parpar # Path to PAR2 executable
   redundancy: "1n*1.2" # [Redundancy level](https://github.com/animetosho/ParPar/blob/6feee4dd94bb18480f0bf08cd9d17ffc7e671b69/help-full.txt#L75)
   volume_size: 153600000 # Size of each volume (150MB)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/sync v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -213,7 +214,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/telemetry v0.0.0-20250310203348-fdfaad844314 // indirect
 	golang.org/x/term v0.31.0 // indirect

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -5,16 +5,21 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/javi11/postie/internal/config"
+	"github.com/javi11/postie/internal/nzb"
 	"github.com/javi11/postie/internal/par2"
 	"github.com/javi11/postie/internal/poster"
 	"github.com/javi11/postie/pkg/fileinfo"
+	"golang.org/x/sync/errgroup"
 )
 
 type Postie struct {
-	cfg        config.Config
+	par2Cfg    *config.Par2Config
+	postingCfg config.PostingConfig
 	par2runner *par2.Par2CmdExecutor
 	poster     poster.Poster
 }
@@ -42,7 +47,7 @@ func New(
 		return nil, err
 	}
 
-	return &Postie{cfg: cfg, par2runner: par2runner, poster: p}, nil
+	return &Postie{par2Cfg: par2Cfg, par2runner: par2runner, poster: p, postingCfg: postingConfig}, nil
 }
 
 func (p *Postie) Post(ctx context.Context, files []fileinfo.FileInfo, rootDir string, outputDir string) error {
@@ -56,31 +61,13 @@ func (p *Postie) Post(ctx context.Context, files []fileinfo.FileInfo, rootDir st
 	for _, f := range files {
 		slog.InfoContext(ctx, "Posting file", "file", f.Path)
 
-		createdPar2Paths, err := p.par2runner.Create(ctx, []fileinfo.FileInfo{f})
-		if err != nil {
-			slog.ErrorContext(ctx, "Error during par2 creation", "error", err)
-
-			return err
-		}
-
-		filesPath := []string{f.Path}
-		filesPath = append(filesPath, createdPar2Paths...)
-
-		if err := p.poster.Post(ctx, filesPath, rootDir, outputDir); err != nil {
-			slog.ErrorContext(ctx, fmt.Sprintf("Error during upload: %s", filesPath), "error", err)
-
-			for _, p := range createdPar2Paths {
-				if err := os.Remove(p); err != nil {
-					slog.ErrorContext(ctx, "Error during par2 cleanup", "error", err)
-				}
+		if *p.postingCfg.WaitForPar2 {
+			if err := p.post(ctx, f, rootDir, outputDir); err != nil {
+				return err
 			}
-
-			return err
-		}
-
-		for _, p := range createdPar2Paths {
-			if err := os.Remove(p); err != nil {
-				slog.ErrorContext(ctx, "Error during par2 cleanup", "error", err)
+		} else {
+			if err := p.postInParallel(ctx, f, rootDir, outputDir); err != nil {
+				return err
 			}
 		}
 	}
@@ -94,6 +81,127 @@ func (p *Postie) Post(ctx context.Context, files []fileinfo.FileInfo, rootDir st
 	slog.InfoContext(ctx, "Articles checked", "count", stats.ArticlesChecked)
 	slog.InfoContext(ctx, "Total bytes", "count", stats.BytesPosted)
 	slog.InfoContext(ctx, "Errors", "count", stats.ArticleErrors)
+
+	return nil
+}
+
+func (p *Postie) postInParallel(
+	ctx context.Context,
+	f fileinfo.FileInfo,
+	rootDir string,
+	outputDir string,
+) error {
+	var (
+		createdPar2Paths []string
+		err              error
+	)
+	defer func() {
+		for _, p := range createdPar2Paths {
+			if err := os.Remove(p); err != nil {
+				slog.ErrorContext(ctx, "Error during par2 cleanup", "error", err)
+			}
+		}
+	}()
+
+	nzbGen := nzb.NewGenerator(p.postingCfg.ArticleSizeInBytes)
+	errg := errgroup.Group{}
+
+	errg.Go(func() error {
+		createdPar2Paths, err = p.par2runner.Create(ctx, []fileinfo.FileInfo{f})
+		if err != nil {
+			slog.ErrorContext(ctx, "Error during par2 creation. Upload will continue without par2.", "error", err)
+
+			return nil
+		}
+
+		if err := p.poster.Post(ctx, createdPar2Paths, rootDir, nzbGen); err != nil {
+			slog.ErrorContext(ctx, fmt.Sprintf("Error during upload of par2 files: %s. Upload will continue without par2.", createdPar2Paths), "error", err)
+
+			return nil
+		}
+
+		return nil
+	})
+
+	errg.Go(func() error {
+		if err := p.poster.Post(ctx, []string{f.Path}, rootDir, nzbGen); err != nil {
+			slog.ErrorContext(ctx, fmt.Sprintf("Error during upload: %s", f.Path), "error", err)
+
+			return err
+		}
+
+		return nil
+	})
+
+	if err := errg.Wait(); err != nil {
+		return err
+	}
+
+	// Generate single NZB file for all files
+	dirPath := filepath.Dir(f.Path)
+	dirPath = strings.TrimPrefix(dirPath, rootDir)
+
+	nzbPath := filepath.Join(outputDir, dirPath, filepath.Base(f.Path)+".nzb")
+	if err := nzbGen.Generate(nzbPath); err != nil {
+		return fmt.Errorf("error generating NZB file: %w", err)
+	}
+
+	return nil
+}
+
+func (p *Postie) post(
+	ctx context.Context,
+	f fileinfo.FileInfo,
+	rootDir string,
+	outputDir string,
+) error {
+	var (
+		createdPar2Paths []string
+		err              error
+	)
+
+	defer func() {
+		for _, p := range createdPar2Paths {
+			if err := os.Remove(p); err != nil {
+				slog.ErrorContext(ctx, "Error during par2 cleanup", "error", err)
+			}
+		}
+	}()
+
+	filesPath := []string{f.Path}
+	nzbGen := nzb.NewGenerator(p.postingCfg.ArticleSizeInBytes)
+
+	if *p.par2Cfg.Enabled {
+		createdPar2Paths, err = p.par2runner.Create(ctx, []fileinfo.FileInfo{f})
+		if err != nil {
+			slog.ErrorContext(ctx, "Error during par2 creation", "error", err)
+
+			return err
+		}
+
+		filesPath = append(filesPath, createdPar2Paths...)
+	}
+
+	if err := p.poster.Post(ctx, filesPath, rootDir, nzbGen); err != nil {
+		slog.ErrorContext(ctx, fmt.Sprintf("Error during upload: %s", filesPath), "error", err)
+
+		return err
+	}
+
+	for _, p := range createdPar2Paths {
+		if err := os.Remove(p); err != nil {
+			slog.ErrorContext(ctx, "Error during par2 cleanup", "error", err)
+		}
+	}
+
+	// Generate single NZB file for all files
+	dirPath := filepath.Dir(f.Path)
+	dirPath = strings.TrimPrefix(dirPath, rootDir)
+
+	nzbPath := filepath.Join(outputDir, dirPath, filepath.Base(f.Path)+".nzb")
+	if err := nzbGen.Generate(nzbPath); err != nil {
+		return fmt.Errorf("error generating NZB file: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
- Added `wait_for_par2` option to control posting behavior relative to Par2 file generation.
- Updated `Par2Config` and `PostingConfig` structures to use pointers for optional fields.
- Refactored posting methods to support parallel uploads and improved error handling during Par2 creation.
- Introduced logging for potential issues when Par2 is disabled but `wait_for_par2` is enabled.