### PR TITLE
feat: add NZB compression configuration and support

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -45,6 +45,12 @@ par2:
   max_input_slices: 4000
   extra_par2_options: []
 
+# NZB compression configuration
+nzb_compression:
+  enabled: false # Whether to enable compression of the output NZB file
+  type: zstd # Options: none, zstd, brotli
+  level: 5 # Compression level (zstd: 0-5, brotli: 0-11)
+
 # Watcher configuration
 watcher:
   size_threshold: 104857600 # 100MB

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -59,6 +59,11 @@ par2:
   max_input_slices: 4000
   extra_par2_options: []
 
+nzb_compression:
+  enabled: false # Whether to enable compression of the output NZB file
+  type: zstd # Options: none, zstd, brotli
+  level: 3 # Compression level (zstd: 1-22, brotli: 0-11)
+
 watcher:
   size_threshold: 104857600 # 100MB
   schedule:
@@ -166,6 +171,30 @@ par2:
   max_input_slices: 4000 # Maximum number of input slices
   extra_par2_options: [] # Additional PAR2 command line options
 ```
+
+### NZB Compression
+
+Configure NZB file compression:
+
+```yaml
+nzb_compression:
+  enabled: false # Whether to enable compression of the output NZB file
+  type: zstd # Compression algorithm to use (options: none, zstd, brotli)
+  level: 3 # Compression level (zstd: 0-5, brotli: 0-11)
+```
+
+When compression is enabled, the generated NZB files will be compressed using the specified algorithm and will have the appropriate file extension added (`.nzb.zst` for zstd or `.nzb.br` for brotli). This can significantly reduce the size of NZB files, especially for large uploads with many segments.
+
+#### Compression Types
+
+- **none**: No compression (default)
+- **zstd**: [Zstandard compression](https://github.com/facebook/zstd) - fast compression with good ratios
+- **brotli**: [Brotli compression](https://github.com/google/brotli) - higher compression ratios but slower
+
+#### Compression Levels
+
+- **zstd**: 0-5 (higher = better compression but slower, default: 3)
+- **brotli**: 0-11 (higher = better compression but slower, default: 4)
 
 ### File Watcher
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect
 	github.com/alingse/nilnesserr v0.2.0 // indirect
+	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/ashanbrown/forbidigo v1.6.0 // indirect
 	github.com/ashanbrown/makezero v1.2.0 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
@@ -119,6 +120,7 @@ require (
 	github.com/karamaru-alpha/copyloopvar v1.2.1 // indirect
 	github.com/kisielk/errcheck v1.9.0 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.14 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/alingse/asasalint v0.0.11 h1:SFwnQXJ49Kx/1GghOFz1XGqHYKp21Kq1nHad/0WQ
 github.com/alingse/asasalint v0.0.11/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/alingse/nilnesserr v0.2.0 h1:raLem5KG7EFVb4UIDAXgrv3N2JIaffeKNtcEXkEWd/w=
 github.com/alingse/nilnesserr v0.2.0/go.mod h1:1xJPrXonEtX7wyTq8Dytns5P2hNzoWymVUIaKm4HNFg=
+github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
+github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/ashanbrown/forbidigo v1.6.0 h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8gerOIVIY=
 github.com/ashanbrown/forbidigo v1.6.0/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.2.0 h1:/2Lp1bypdmK9wDIq7uWBlDF1iMUpIIS4A+pF6C9IEUU=
@@ -259,6 +261,8 @@ github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -478,6 +482,7 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yagipy/maintidx v1.0.0 h1:h5NvIsCz+nRDapQ0exNv4aJ0yXSI0420omVANTv3GJM=
 github.com/yagipy/maintidx v1.0.0/go.mod h1:0qNf/I/CCZXSMhsRsrEPDZ+DkekpKLXAJfsTACwgXLk=
 github.com/yeya24/promlinter v0.3.0 h1:JVDbMp08lVCP7Y6NP3qHroGAO6z2yGKQtS5JsjqtoFs=


### PR DESCRIPTION
Introduced NZB compression settings in the configuration, allowing users to enable compression for output NZB files using either zstd or brotli algorithms. Updated the NZB generator to handle compression based on user-defined settings, including compression levels. Enhanced documentation to reflect these changes and provide guidance on configuration options.