### PR TITLE
fix: enhance duplicate file handling in watcher

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -14,6 +14,17 @@ import (
 	"maragu.dev/goqite"
 )
 
+var _ QueueInterface = (*Queue)(nil)
+
+// QueueInterface defines the interface for queue operations
+type QueueInterface interface {
+	AddFile(ctx context.Context, path string, size int64) error
+	GetQueueItems() ([]QueueItem, error)
+	RemoveFromQueue(id string) error
+	ClearQueue() error
+	GetQueueStats() (map[string]interface{}, error)
+}
+
 type Queue struct {
 	queue     *goqite.Queue
 	db        *sql.DB


### PR DESCRIPTION
This pull request introduces a new `QueueInterface` to decouple the queue implementation from its usage in the watcher, improving testability and flexibility. It also enhances duplicate prevention logic in the watcher and adds comprehensive tests to ensure correctness.

### Interface and Refactoring Changes:

* Added `QueueInterface` to define the contract for queue operations, implemented by the `Queue` struct in `internal/queue/queue.go`. This allows for easier mocking and testing.
* Updated the `Watcher` struct in `internal/watcher/watcher.go` to use the `QueueInterface` instead of directly depending on the `Queue` struct. This change ensures the watcher is decoupled from the queue implementation. [[1]](diffhunk://#diff-f60b44bc150ee850a6d078799aff0808a7cdadd36159d76bd8bd15f4b7cc9c0eL25-R25) [[2]](diffhunk://#diff-f60b44bc150ee850a6d078799aff0808a7cdadd36159d76bd8bd15f4b7cc9c0eL40-R47)

### Duplicate Prevention Logic:

* Modified the `scanDirectory` method in `internal/watcher/watcher.go` to always check for duplicates before adding files to the queue, regardless of the `DeleteOriginalFile` setting, ensuring queue integrity.

### Testing Enhancements:

* Introduced `mockQueueWithDuplicateCheck` in `internal/watcher/watcher_test.go` to simulate queue behavior with duplicate prevention, enabling robust testing of the watcher logic.
* Added new test cases, `TestDuplicatePrevention` and `TestMultipleScanCycles`, to validate duplicate prevention and ensure files are only added to the queue once across multiple scans.