### PR TITLE
fix: implement IsPathInQueue method for duplicate checking in queue

### DIFF
--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -97,6 +97,16 @@ func (m *mockQueueWithDuplicateCheck) EnsureMigrationCompatibility() error {
 	return nil
 }
 
+func (m *mockQueueWithDuplicateCheck) IsPathInQueue(path string) (bool, error) {
+	// Check if this path has already been added to our mock queue
+	for _, addedPath := range m.addFileCalls {
+		if addedPath == path {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Helper function to create a test watcher
 func createTestWatcher(t *testing.T) (*Watcher, string) {
 	tempDir := t.TempDir()


### PR DESCRIPTION
This pull request refactors the queue logic by introducing a new method, `IsPathInQueue`, to centralize duplicate path-checking functionality. This change improves code clarity, reduces redundancy, and ensures consistent behavior across the queue and watcher components.

### Refactoring and Centralization of Duplicate Path Checking:
* Added a new method `IsPathInQueue` to the `QueueInterface` in `internal/queue/queue.go`. This method checks if a file path already exists in the queue (pending, completed, or errored items). (`[[1]](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bR35)`, `[[2]](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bL723-R730)`)
* Replaced calls to the previously private `pathExists` method with the new `IsPathInQueue` method in `AddFile` and `AddFileWithPriority` functions in `internal/queue/queue.go`. (`[[1]](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bL182-R183)`, `[[2]](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bL239-R240)`)

### Enhancements to Watcher Logic:
* Updated the `scanDirectory` method in `internal/watcher/watcher.go` to use the `IsPathInQueue` method for duplicate checking. This ensures that files already in the queue are skipped, improving efficiency and avoiding queue pollution. (`[internal/watcher/watcher.goL127-R139](diffhunk://#diff-f60b44bc150ee850a6d078799aff0808a7cdadd36159d76bd8bd15f4b7cc9c0eL127-R139)`)

### Updates to Testing:
* Added an implementation of the `IsPathInQueue` method to the `mockQueueWithDuplicateCheck` struct in `internal/watcher/watcher_test.go` to support testing of the updated watcher logic. (`[internal/watcher/watcher_test.goR100-R109](diffhunk://#diff-78ece1e278ff48b25ccc1e8baa1561932e2fab2830683dc70bc17848da6df67cR100-R109)`)