### PR TITLE
fix: improve watch directory existence check and error handling

### DIFF
--- a/internal/backend/queue.go
+++ b/internal/backend/queue.go
@@ -65,9 +65,13 @@ func (a *App) initializeQueue() error {
 		outputDir = filepath.Join(a.appPaths.Data, outputDir)
 	}
 
-	// Ensure output directory exists (always needed for queue operations)
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return fmt.Errorf("failed to create output directory: %w", err)
+	// Ensure watch directory exists - only set permissions if creating new directory
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to check output directory: %w", err)
 	}
 
 	// Create context for queue and processor
@@ -87,7 +91,7 @@ func (a *App) initializeQueue() error {
 // AddFilesToQueue adds multiple files to the queue for processing
 func (a *App) AddFilesToQueue() error {
 	defer a.recoverPanic("AddFilesToQueue")
-	
+
 	if a.queue == nil {
 		slog.Error("Queue not initialized - this should not happen")
 		return fmt.Errorf("queue not initialized - please restart the application")
@@ -140,7 +144,7 @@ func (a *App) AddFilesToQueue() error {
 // GetQueueItems returns the current queue items from the queue
 func (a *App) GetQueueItems() ([]QueueItem, error) {
 	defer a.recoverPanic("GetQueueItems")
-	
+
 	if a.queue == nil {
 		return []QueueItem{}, nil
 	}

--- a/internal/backend/watcher.go
+++ b/internal/backend/watcher.go
@@ -48,9 +48,13 @@ func (a *App) initializeWatcher() error {
 		watchDir = filepath.Join(a.appPaths.Data, "watch")
 	}
 
-	// Ensure watch directory exists
-	if err := os.MkdirAll(watchDir, 0755); err != nil {
-		return fmt.Errorf("failed to create watch directory: %w", err)
+	// Ensure watch directory exists - only set permissions if creating new directory
+	if _, err := os.Stat(watchDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(watchDir, 0755); err != nil {
+			return fmt.Errorf("failed to create watch directory: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to check watch directory: %w", err)
 	}
 
 	// Create separate context for watcher


### PR DESCRIPTION
This pull request refines the logic for ensuring directory existence in the backend queue and watcher initialization processes. The main improvement is that the code now only sets directory permissions when creating a new directory, and it adds better error handling for existing directories.

Directory existence and error handling improvements:

* In `internal/backend/queue.go`, the `initializeQueue` function now checks if the output directory exists before attempting to create it, and only sets permissions if the directory is newly created. It also provides clearer error reporting if the directory check fails.
* In `internal/backend/watcher.go`, the `initializeWatcher` function applies the same logic to the watch directory, ensuring permissions are only set when the directory is created and improving error handling for directory checks.