### PR TITLE
fix: add ignore patterns on watch

### DIFF
--- a/cmd/postie/watch.go
+++ b/cmd/postie/watch.go
@@ -64,7 +64,7 @@ The watch command will monitor the configured directory and upload files accordi
 
 		if _, err := os.Stat(outputFolder); os.IsNotExist(err) {
 			if err := os.MkdirAll(outputFolder, 0755); err != nil {
-				return fmt.Errorf("failed to create output directory: %w", err)
+				return fmt.Errorf("failed to create output directory: %w, %s", err, outputFolder)
 			}
 		} else if err != nil {
 			return fmt.Errorf("failed to check output directory: %w", err)

--- a/internal/backend/queue.go
+++ b/internal/backend/queue.go
@@ -75,10 +75,10 @@ func (a *App) initializeQueue() error {
 	// Ensure watch directory exists - only set permissions if creating new directory
 	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
-			return fmt.Errorf("failed to create output directory: %w", err)
+			return fmt.Errorf("failed to create output directory: %w, %s", err, outputDir)
 		}
 	} else if err != nil {
-		return fmt.Errorf("failed to check output directory: %w", err)
+		return fmt.Errorf("failed to check output directory: %w, %s", err, outputDir)
 	}
 
 	// Create context for queue and processor
@@ -89,7 +89,7 @@ func (a *App) initializeQueue() error {
 	if err != nil {
 		return fmt.Errorf("failed to create database: %w", err)
 	}
-	
+
 	// Store database reference for cleanup
 	a.database = db
 

--- a/internal/nzb/nzb.go
+++ b/internal/nzb/nzb.go
@@ -147,10 +147,10 @@ func (g *Generator) Generate(outputPath string) (string, error) {
 	// Create output directory if it doesn't exist
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(outputPath, 0755); err != nil {
-			return "", fmt.Errorf("failed to create output directory: %w", err)
+			return "", fmt.Errorf("failed to create output directory: %w, %s", err, outputPath)
 		}
 	} else if err != nil {
-		return "", fmt.Errorf("failed to check output directory: %w", err)
+		return "", fmt.Errorf("failed to check output directory: %w, %s", err, outputPath)
 	}
 
 	// Write NZB file


### PR DESCRIPTION
This pull request introduces several improvements to watcher configuration management in the frontend and enhances thread safety and error reporting in backend processing. The main changes include refactoring how ignore patterns are handled in the watcher settings UI, improving error messages related to output directory creation, and making the processor's pool manager usage thread-safe to prevent race conditions during shutdown or provider checks.

**Frontend: Watcher Settings Improvements**
* Refactored ignore pattern management in `WatcherSection.svelte` to use a local `ignorePatterns` state variable instead of directly mutating `config.watcher.ignore_patterns`. This change ensures better reactivity and cleaner state handling. The ignore patterns are now synced to the config on save and initialization. [[1]](diffhunk://#diff-7ce4ea9277a538b51f55d7eae988f37c9a2da3bb99de5b9f20dffda4cadf8a54R33) [[2]](diffhunk://#diff-7ce4ea9277a538b51f55d7eae988f37c9a2da3bb99de5b9f20dffda4cadf8a54R82) [[3]](diffhunk://#diff-7ce4ea9277a538b51f55d7eae988f37c9a2da3bb99de5b9f20dffda4cadf8a54R116) [[4]](diffhunk://#diff-7ce4ea9277a538b51f55d7eae988f37c9a2da3bb99de5b9f20dffda4cadf8a54L143-R161) [[5]](diffhunk://#diff-7ce4ea9277a538b51f55d7eae988f37c9a2da3bb99de5b9f20dffda4cadf8a54L406-R406)
* Added initialization of `config.watcher` if it does not exist, preventing possible runtime errors when updating watcher settings.

**Backend: Error Reporting & Thread Safety**
* Enhanced error messages for output directory creation and checks by including the directory path in the error output in `watch.go`, `queue.go`, and `nzb.go`. This provides more context for debugging failures. [[1]](diffhunk://#diff-a3dfe17152275ecabda1a6ae1c692a18bf78e85bb3399770f1a9904c899d5b6fL67-R67) [[2]](diffhunk://#diff-09ac4674aa28cd217fbdfeb928b0f5fda2b80a04a946eef5676e64100439ab65L78-R81) [[3]](diffhunk://#diff-29f7ae637e3aacf2b34e0165db9e63a35a3c1c4318628e07c86882f562f0ad49L150-R153)
* Made access to the processor's `poolManager` thread-safe with mutex locks, ensuring that no new jobs are processed after shutdown is initiated and preventing race conditions during provider availability checks. [[1]](diffhunk://#diff-2beffd8a2ba7a8709c1ec57c621876197093ed74459de9baf4f1732636380e65R185-R201) [[2]](diffhunk://#diff-2beffd8a2ba7a8709c1ec57c621876197093ed74459de9baf4f1732636380e65R291-R301) [[3]](diffhunk://#diff-2beffd8a2ba7a8709c1ec57c621876197093ed74459de9baf4f1732636380e65R503-R507) [[4]](diffhunk://#diff-2beffd8a2ba7a8709c1ec57c621876197093ed74459de9baf4f1732636380e65L568-R609)