### PR TITLE
feat(queue): implement paginated queue item retrieval

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2,6 +2,7 @@
 
 import { browser } from "$app/environment";
 import type { backend, config, processor, watcher } from "$lib/wailsjs/go/models";
+// Using backend types for pagination - remove temporary types import
 import type { WebClient } from "./web-client";
 
 type WailsApp = typeof import("$lib/wailsjs/go/backend/App");
@@ -180,6 +181,22 @@ export class UnifiedClient {
 		if (this._environment === "web") {
 			const client = await getWebClient();
 			return client.getQueueItems();
+		}
+
+		throw new Error("No client available");
+	}
+
+	async getQueueItemsPaginated(params: backend.PaginationParams): Promise<backend.PaginatedQueueResult> {
+		await this.initialize();
+
+		if (this._environment === "wails") {
+			const client = await getWailsClient();
+			return client.App.GetQueueItemsPaginated(params);
+		}
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.getQueueItemsPaginated(params);
 		}
 
 		throw new Error("No client available");

--- a/frontend/src/lib/api/web-client.ts
+++ b/frontend/src/lib/api/web-client.ts
@@ -1,6 +1,7 @@
 // Web API client for browser environment (replaces Wails bindings)
 
 import type { backend, config, processor, watcher } from "$lib/wailsjs/go/models";
+// Using backend types for pagination
 
 const API_BASE = "/api";
 
@@ -158,6 +159,16 @@ export class WebClient {
 	// Queue methods
 	async getQueueItems(): Promise<backend.QueueItem[]> {
 		return this.get<backend.QueueItem[]>("/queue");
+	}
+
+	async getQueueItemsPaginated(params: backend.PaginationParams): Promise<backend.PaginatedQueueResult> {
+		const queryParams = new URLSearchParams({
+			page: params.page.toString(),
+			limit: params.limit.toString(),
+			sortBy: params.sortBy,
+			order: params.order,
+		});
+		return this.get<backend.PaginatedQueueResult>(`/queue/paginated?${queryParams}`);
 	}
 
 	async getQueueStats(): Promise<backend.QueueStats> {

--- a/frontend/src/lib/locales/en/setup.json
+++ b/frontend/src/lib/locales/en/setup.json
@@ -69,6 +69,24 @@
 		},
 		"messages": {
 			"setupRequired": "Setup is required to use Postie. Please complete the setup wizard."
+		},
+		"success_title": "Setup Complete!",
+		"success_message": "Your Postie configuration has been saved successfully. You can now start uploading files.",
+		"errors": {
+			"server_validation_title": "Server Connection Failed",
+			"server_validation_message": "Unable to connect to one or more NNTP servers. Please verify your credentials and network connection.",
+			"filesystem_title": "File Permission Error",
+			"filesystem_message": "Unable to save configuration due to file system permissions. Please check write access.",
+			"config_save_title": "Configuration Save Failed",
+			"config_save_message": "Failed to save your configuration. Please ensure sufficient disk space and try again.",
+			"invalid_input_title": "Invalid Configuration",
+			"invalid_input_message": "Some configuration values are invalid. Please review and correct your settings.",
+			"network_title": "Network Error",
+			"network_message": "Unable to connect to the server. Please check your internet connection and try again.",
+			"timeout_title": "Request Timeout",
+			"timeout_message": "The setup request took too long to complete. Please try again.",
+			"generic_title": "Setup Failed",
+			"generic_message": "An unexpected error occurred during setup. Please try again."
 		}
 	}
 }

--- a/frontend/src/lib/wailsjs/go/backend/App.d.ts
+++ b/frontend/src/lib/wailsjs/go/backend/App.d.ts
@@ -52,6 +52,8 @@ export function GetProcessorStatus():Promise<backend.ProcessorStatus>;
 
 export function GetQueueItems():Promise<Array<backend.QueueItem>>;
 
+export function GetQueueItemsPaginated(arg1:backend.PaginationParams):Promise<backend.PaginatedQueueResult>;
+
 export function GetQueueStats():Promise<backend.QueueStats>;
 
 export function GetRunningJobs():Promise<Array<processor.RunningJobItem>>;

--- a/frontend/src/lib/wailsjs/go/backend/App.js
+++ b/frontend/src/lib/wailsjs/go/backend/App.js
@@ -94,6 +94,10 @@ export function GetQueueItems() {
   return window['go']['backend']['App']['GetQueueItems']();
 }
 
+export function GetQueueItemsPaginated(arg1) {
+  return window['go']['backend']['App']['GetQueueItemsPaginated'](arg1);
+}
+
 export function GetQueueStats() {
   return window['go']['backend']['App']['GetQueueStats']();
 }

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -173,22 +173,6 @@ export namespace backend {
 		}
 	}
 	
-	export class ProcessorStatus {
-	    hasProcessor: boolean;
-	    runningJobs: number;
-	    runningJobIDs: string[];
-	
-	    static createFrom(source: any = {}) {
-	        return new ProcessorStatus(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.hasProcessor = source["hasProcessor"];
-	        this.runningJobs = source["runningJobs"];
-	        this.runningJobIDs = source["runningJobIDs"];
-	    }
-	}
 	export class QueueItem {
 	    id: string;
 	    path: string;
@@ -244,6 +228,83 @@ export namespace backend {
 		    return a;
 		}
 	}
+	export class PaginatedQueueResult {
+	    items: QueueItem[];
+	    totalItems: number;
+	    totalPages: number;
+	    currentPage: number;
+	    itemsPerPage: number;
+	    hasNext: boolean;
+	    hasPrev: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new PaginatedQueueResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.items = this.convertValues(source["items"], QueueItem);
+	        this.totalItems = source["totalItems"];
+	        this.totalPages = source["totalPages"];
+	        this.currentPage = source["currentPage"];
+	        this.itemsPerPage = source["itemsPerPage"];
+	        this.hasNext = source["hasNext"];
+	        this.hasPrev = source["hasPrev"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class PaginationParams {
+	    page: number;
+	    limit: number;
+	    sortBy: string;
+	    order: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new PaginationParams(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.page = source["page"];
+	        this.limit = source["limit"];
+	        this.sortBy = source["sortBy"];
+	        this.order = source["order"];
+	    }
+	}
+	export class ProcessorStatus {
+	    hasProcessor: boolean;
+	    runningJobs: number;
+	    runningJobIDs: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new ProcessorStatus(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.hasProcessor = source["hasProcessor"];
+	        this.runningJobs = source["runningJobs"];
+	        this.runningJobIDs = source["runningJobIDs"];
+	    }
+	}
+	
 	export class QueueStats {
 	    total: number;
 	    pending: number;

--- a/frontend/src/routes/setup/+page.svelte
+++ b/frontend/src/routes/setup/+page.svelte
@@ -33,6 +33,71 @@ $effect(() => {
 	checkAppStatus();
 });
 
+// Enhanced error handling for structured API responses
+function parseApiError(error: any): { title: string; message: string; details?: string } {
+	// Check if it's a structured error response from our API
+	if (error?.response?.data?.error) {
+		const apiError = error.response.data;
+		
+		// Map error codes to user-friendly messages
+		switch (apiError.code) {
+			case 'SERVER_VALIDATION_FAILED':
+				return {
+					title: $t("setup.errors.server_validation_title"),
+					message: $t("setup.errors.server_validation_message"),
+					details: apiError.details
+				};
+			case 'FILESYSTEM_ERROR':
+				return {
+					title: $t("setup.errors.filesystem_title"),
+					message: $t("setup.errors.filesystem_message"),
+					details: apiError.details
+				};
+			case 'CONFIG_SAVE_FAILED':
+				return {
+					title: $t("setup.errors.config_save_title"),
+					message: $t("setup.errors.config_save_message"),
+					details: apiError.details
+				};
+			case 'INVALID_INPUT':
+				return {
+					title: $t("setup.errors.invalid_input_title"),
+					message: $t("setup.errors.invalid_input_message"),
+					details: apiError.details
+				};
+			default:
+				return {
+					title: $t("setup.errors.generic_title"),
+					message: apiError.message || $t("setup.errors.generic_message"),
+					details: apiError.details
+				};
+		}
+	}
+	
+	// Handle network errors
+	if (error?.code === 'NETWORK_ERROR' || error?.message?.includes('Network Error')) {
+		return {
+			title: $t("setup.errors.network_title"),
+			message: $t("setup.errors.network_message")
+		};
+	}
+	
+	// Handle timeout errors
+	if (error?.code === 'ECONNABORTED' || error?.message?.includes('timeout')) {
+		return {
+			title: $t("setup.errors.timeout_title"),
+			message: $t("setup.errors.timeout_message")
+		};
+	}
+	
+	// Fallback for unknown errors
+	const errorMessage = error instanceof Error ? error.message : String(error);
+	return {
+		title: $t("common.common.error"),
+		message: errorMessage
+	};
+}
+
 async function handleWizardComplete(
 	data: backend.SetupWizardData,
 ): Promise<void> {
@@ -40,21 +105,26 @@ async function handleWizardComplete(
 		await apiClient.setupWizardComplete(data);
 
 		toastStore.success(
-			$t("common.common.success"),
-			$t("common.messages.configuration_saved_description"),
+			$t("setup.success_title"),
+			$t("setup.success_message"),
 		);
 
 		// Redirect to dashboard
 		goto("/");
 		return;
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error);
 		console.error("Setup wizard failed:", error);
-
-		toastStore.error(
-			$t("common.common.error"),
-			errorMessage,
-		);
+		
+		// Parse the error and show user-friendly message
+		const { title, message, details } = parseApiError(error);
+		
+		// Show detailed error in toast
+		let fullMessage = message;
+		if (details) {
+			fullMessage += `\n\n${details}`;
+		}
+		
+		toastStore.error(title, fullMessage);
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -26,13 +26,13 @@ type PaginationParams struct {
 
 // PaginatedResult contains paginated queue items and metadata
 type PaginatedResult struct {
-	Items      []QueueItem `json:"items"`
-	TotalItems int         `json:"totalItems"`
-	TotalPages int         `json:"totalPages"`
-	CurrentPage int        `json:"currentPage"`
-	ItemsPerPage int       `json:"itemsPerPage"`
-	HasNext    bool        `json:"hasNext"`
-	HasPrev    bool        `json:"hasPrev"`
+	Items        []QueueItem `json:"items"`
+	TotalItems   int         `json:"totalItems"`
+	TotalPages   int         `json:"totalPages"`
+	CurrentPage  int         `json:"currentPage"`
+	ItemsPerPage int         `json:"itemsPerPage"`
+	HasNext      bool        `json:"hasNext"`
+	HasPrev      bool        `json:"hasPrev"`
 }
 
 // QueueInterface defines the interface for queue operations
@@ -115,7 +115,6 @@ func New(ctx context.Context, database *database.Database) (*Queue, error) {
 		runCancel: runCancel,
 	}, nil
 }
-
 
 // AddFile adds a file to the queue for processing
 func (q *Queue) AddFile(ctx context.Context, path string, size int64) error {
@@ -486,7 +485,7 @@ func (q *Queue) GetQueueItemsPaginated(params PaginationParams) (*PaginatedResul
 
 	// Get total counts first
 	var activeCount, completedCount, erroredCount int
-	
+
 	err := q.db.QueryRow("SELECT COUNT(*) FROM goqite WHERE queue = 'file_jobs'").Scan(&activeCount)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active items count: %w", err)
@@ -533,7 +532,7 @@ func (q *Queue) GetQueueItemsPaginated(params PaginationParams) (*PaginatedResul
 
 	// Calculate pagination metadata
 	totalPages := (totalCount + params.Limit - 1) / params.Limit // Ceiling division
-	
+
 	result := &PaginatedResult{
 		Items:        allItems,
 		TotalItems:   totalCount,
@@ -620,7 +619,9 @@ func (q *Queue) getMergedItemsPaginated(orderBy string, offset, limit int) ([]Qu
 	if err != nil {
 		return nil, fmt.Errorf("failed to query paginated items: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	var items []QueueItem
 	for rows.Next() {
@@ -730,7 +731,9 @@ func (q *Queue) getActiveItemsPaginated(offset, limit int) ([]QueueItem, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	var items []QueueItem
 	for rows.Next() {
@@ -750,15 +753,15 @@ func (q *Queue) getActiveItemsPaginated(offset, limit int) ([]QueueItem, error) 
 		updatedTime, _ := time.Parse("2006-01-02T15:04:05.000Z", updated)
 
 		item := QueueItem{
-			ID:          id,
-			Path:        job.Path,
-			FileName:    getFileName(job.Path),
-			Size:        job.Size,
-			Status:      StatusPending,
-			RetryCount:  job.RetryCount,
-			Priority:    job.Priority,
-			CreatedAt:   createdTime,
-			UpdatedAt:   updatedTime,
+			ID:         id,
+			Path:       job.Path,
+			FileName:   getFileName(job.Path),
+			Size:       job.Size,
+			Status:     StatusPending,
+			RetryCount: job.RetryCount,
+			Priority:   job.Priority,
+			CreatedAt:  createdTime,
+			UpdatedAt:  updatedTime,
 		}
 
 		items = append(items, item)
@@ -776,7 +779,9 @@ func (q *Queue) getCompletedItemsPaginated(offset, limit int) ([]QueueItem, erro
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	var items []QueueItem
 	for rows.Next() {
@@ -820,7 +825,9 @@ func (q *Queue) getErroredItemsPaginated(offset, limit int) ([]QueueItem, error)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	var items []QueueItem
 	for rows.Next() {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -435,7 +435,7 @@ func (w *Watcher) getNextScheduledRun(now time.Time) time.Time {
 	startHour := 0
 	startMin := 0
 	if len(startTime) >= 5 {
-		fmt.Sscanf(startTime, "%d:%d", &startHour, &startMin)
+		_, _ = fmt.Sscanf(startTime, "%d:%d", &startHour, &startMin)
 	}
 
 	// Calculate start time for today

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -80,7 +80,7 @@ func (p *Postie) Close() {
 	}
 }
 
-// safeRemoveFile attempts to remove a file with retry logic for Windows compatibility
+// safeRemoveFile attempts to remove a file with retry logic
 func safeRemoveFile(ctx context.Context, filePath string) {
 	maxRetries := 3
 	baseDelay := 100 * time.Millisecond
@@ -103,13 +103,8 @@ func safeRemoveFile(ctx context.Context, filePath string) {
 		}
 	}
 
-	// Final attempt with detailed error logging
-	if err := os.Remove(filePath); err != nil {
-		slog.ErrorContext(ctx, "Failed to remove file after retries",
-			"file", filePath,
-			"error", err,
-			"os", runtime.GOOS)
-	}
+	// Final attempt if error just ignore it is a tmp file it will be deleted automatically
+	_ = os.Remove(filePath)
 }
 
 func (p *Postie) Post(ctx context.Context, files []fileinfo.FileInfo, rootDir string, outputDir string) (string, error) {


### PR DESCRIPTION
- Added `getQueueItemsPaginated` method to `WebClient` for fetching paginated queue items from the API.
- Updated `QueueSection.svelte` to handle pagination state and display paginated results.
- Enhanced backend with `PaginationParams` and `PaginatedQueueResult` structures for managing pagination.
- Implemented pagination logic in the queue management system, including sorting and item limits.
- Improved error handling in the setup wizard with structured API responses.
- Added detailed logging for server connection validation and setup completion.

Fix #43 
Related #41 