### PR TITLE
feat: multiple files in one nzb

### DIFF
--- a/cmd/postie/watch.go
+++ b/cmd/postie/watch.go
@@ -132,8 +132,11 @@ The watch command will monitor the configured directory and upload files accordi
 			}
 		}()
 
+		// Get posting config to check singleNzbPerFolder setting
+		postingCfg := cfg.GetPostingConfig()
+		
 		// Create watcher
-		w := watcher.New(watcherCfg, q, proc, watchDir)
+		w := watcher.New(watcherCfg, q, proc, watchDir, postingCfg.SingleNzbPerFolder)
 
 		// Handle shutdown signals
 		sigChan := make(chan os.Signal, 1)

--- a/frontend/src/lib/components/settings/PostingSection.svelte
+++ b/frontend/src/lib/components/settings/PostingSection.svelte
@@ -46,6 +46,7 @@ let addNgxHeader = $state(config.posting.post_headers?.add_nxg_header ?? false);
 let throttleRateMB = $state(
 	Math.round((config.posting.throttle_rate || 0) / 1048576),
 );
+let singleNzbPerFolder = $state(config.posting.single_nzb_per_folder ?? false);
 
 // Initialize defaults (following initialization pattern)
 function initializeDefaults() {
@@ -78,6 +79,7 @@ $effect(() => {
 	config.posting.message_id_format = messageIdFormat;
 	config.posting.group_policy = groupPolicy;
 	config.posting.throttle_rate = throttleRateMB * 1048576;
+	config.posting.single_nzb_per_folder = singleNzbPerFolder;
 });
 
 $effect(() => {
@@ -238,6 +240,30 @@ async function savePostingSettings() {
         maxValue={10000000}
         id="article-size"
       />
+
+      <!-- Single NZB Per Folder -->
+      <div class="flex flex-col justify-center">
+        <div class="form-control">
+          <label class="label cursor-pointer justify-start gap-3">
+            <input
+              type="checkbox"
+              class="checkbox checkbox-primary"
+              bind:checked={singleNzbPerFolder}
+            />
+            <span class="label-text font-medium">
+              {$t('settings.posting.single_nzb_per_folder')}
+            </span>
+          </label>
+          <p class="text-sm text-base-content/70 mt-1">
+            {$t('settings.posting.single_nzb_per_folder_description')}
+          </p>
+          <div class="mt-2 p-3 bg-base-200 rounded text-xs">
+            <p class="text-base-content/70">
+              {@html $t('settings.posting.single_nzb_per_folder_info')}
+            </p>
+          </div>
+        </div>
+      </div>
 
       <!-- Advanced Settings (conditionally shown) -->
       {#if $advancedMode}

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -241,6 +241,9 @@
 			"group_policy_description": "How to distribute files across newsgroups",
 			"wait_for_par2": "Wait for PAR2",
 			"wait_for_par2_description": "Wait for PAR2 files to be created before starting upload",
+			"single_nzb_per_folder": "Single NZB Per Folder",
+			"single_nzb_per_folder_description": "Create one NZB per folder instead of one NZB per file. When enabled, all files in a folder will be combined into a single NZB file.",
+			"single_nzb_per_folder_info": "<strong>Watch Mode:</strong> Creates one NZB named after the folder containing all files (e.g., 'folder.nzb' with 'subfolder/file1.mkv' and 'file2.mkv'). <strong>Direct Upload:</strong> When uploading a folder, creates one NZB for the entire folder contents.",
 			"obfuscation": {
 				"none": "None",
 				"partial": "Partial",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -236,6 +236,9 @@
 			"group_policy_description": "Cómo distribuir archivos entre grupos de noticias",
 			"wait_for_par2": "Esperar PAR2",
 			"wait_for_par2_description": "Esperar a que se creen los archivos PAR2 antes de comenzar la carga",
+			"single_nzb_per_folder": "Un Solo NZB Por Carpeta",
+			"single_nzb_per_folder_description": "Crear un NZB por carpeta en lugar de un NZB por archivo. Especialmente útil para sets de archivos organizados en carpetas.",
+			"single_nzb_per_folder_info": "<strong>Modo Observación:</strong> Crea un NZB con el nombre de la carpeta conteniendo todos los archivos con rutas relativas preservadas.<br><strong>Carga Directa:</strong> Al cargar una carpeta, crea un solo NZB para todo el contenido de la carpeta.",
 			"obfuscation": {
 				"none": "Ninguno",
 				"partial": "Parcial",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -236,6 +236,9 @@
 			"group_policy_description": "Comment distribuer les fichiers entre les groupes de nouvelles",
 			"wait_for_par2": "Attendre PAR2",
 			"wait_for_par2_description": "Attendre que les fichiers PAR2 soient créés avant de commencer le téléchargement",
+			"single_nzb_per_folder": "Un Seul NZB Par Dossier",
+			"single_nzb_per_folder_description": "Créer un NZB par dossier au lieu d'un NZB par fichier. Particulièrement utile pour les ensembles de fichiers organisés en dossiers.",
+			"single_nzb_per_folder_info": "<strong>Mode Surveillance :</strong> Crée un NZB nommé d'après le dossier contenant tous les fichiers avec les chemins relatifs préservés.<br><strong>Téléchargement Direct :</strong> Lors du téléchargement d'un dossier, crée un seul NZB pour tout le contenu du dossier.",
 			"obfuscation": {
 				"none": "Aucune",
 				"partial": "Partielle",

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -632,6 +632,7 @@ export namespace config {
 	    obfuscation_policy: string;
 	    par2_obfuscation_policy: string;
 	    group_policy: string;
+	    single_nzb_per_folder: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new PostingConfig(source);
@@ -650,6 +651,7 @@ export namespace config {
 	        this.obfuscation_policy = source["obfuscation_policy"];
 	        this.par2_obfuscation_policy = source["par2_obfuscation_policy"];
 	        this.group_policy = source["group_policy"];
+	        this.single_nzb_per_folder = source["single_nzb_per_folder"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/backend/watcher.go
+++ b/internal/backend/watcher.go
@@ -60,8 +60,11 @@ func (a *App) initializeWatcher() error {
 	// Create separate context for watcher
 	a.watchCtx, a.watchCancel = context.WithCancel(context.Background())
 
+	// Get posting config to check singleNzbPerFolder setting
+	postingCfg := a.config.GetPostingConfig()
+	
 	// Initialize watcher
-	a.watcher = watcher.New(watcherCfg, a.queue, a.processor, watchDir)
+	a.watcher = watcher.New(watcherCfg, a.queue, a.processor, watchDir, postingCfg.SingleNzbPerFolder)
 
 	// Start watcher
 	go func() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -236,6 +236,8 @@ type PostingConfig struct {
 	Par2ObfuscationPolicy ObfuscationPolicy `yaml:"par2_obfuscation_policy" json:"par2_obfuscation_policy"`
 	//  If you give several Groups you've 3 policy when posting
 	GroupPolicy GroupPolicy `yaml:"group_policy" json:"group_policy"`
+	// If true, creates one NZB per folder instead of one NZB per file. Default value is `false`.
+	SingleNzbPerFolder bool `yaml:"single_nzb_per_folder" json:"single_nzb_per_folder"`
 }
 
 type WatcherConfig struct {
@@ -719,6 +721,7 @@ func GetDefaultConfig() ConfigData {
 			ObfuscationPolicy:     ObfuscationPolicyFull,
 			Par2ObfuscationPolicy: ObfuscationPolicyFull,
 			GroupPolicy:           GroupPolicyEachFile,
+			SingleNzbPerFolder:    false, // Default to false for backward compatibility
 		},
 		PostCheck: PostCheck{
 			Enabled:    &enabled,

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -232,7 +232,7 @@ func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
 
 		// Get the parent directory
 		folderPath := filepath.Dir(path)
-		
+
 		// Add file to the folder's file list
 		filesByFolder[folderPath] = append(filesByFolder[folderPath], path)
 		sizeByFolder[folderPath] += info.Size()
@@ -282,7 +282,7 @@ func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
 		// This allows the processor to know which files belong to this folder job
 		folderSize := sizeByFolder[folderPath]
 		folderName := filepath.Base(folderPath)
-		
+
 		slog.InfoContext(ctx, "Adding folder to queue", "folder", folderName, "files", len(files), "size", folderSize)
 
 		// Add the folder to the queue with a special marker to indicate it's a folder

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -124,7 +124,7 @@ func createTestWatcher(t *testing.T) (*Watcher, string) {
 		processingPaths: make(map[string]bool),
 	}
 
-	watcher := New(cfg, mockQueue, mockProc, tempDir)
+	watcher := New(cfg, mockQueue, mockProc, tempDir, false)
 	return watcher, tempDir
 }
 


### PR DESCRIPTION
- Introduced a new configuration option to create a single NZB file per folder instead of one per file.
-  Updated the PostingSection component to include a checkbox for this setting.
- Enhanced the watcher and processor to handle folder uploads as a single NZB when enabled.
- Added localization strings for the new feature in English, Spanish, and French.
- Updated relevant configuration structures and methods to support this functionality.
    
#46 FOlders #58 In the NZB output folder create new folder as nzb file #59