### PR TITLE
fix(web): enable direct URL access for SPA routes in web mode

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 			pages: "build",
 			assets: "build",
 			out: "build",
-			fallback: undefined,
+			fallback: "index.html",
 			precompress: false,
 			strict: true,
 		}),


### PR DESCRIPTION
## Summary
- Fix direct URL access to routes like `/metrics`, `/settings`, `/logs` in web mode
- Add SPA-aware static file serving in Go backend that serves prerendered `.html` files
- Configure SvelteKit static adapter with `fallback: "index.html"` for dynamic routes

## Test plan
- [x] Start the web server (`go run ./cmd/web`)
- [x] Access `http://localhost:8080/metrics` directly in browser
- [x] Verify the metrics page loads (not the dashboard)
- [x] Test other routes: `/settings`, `/logs`, `/setup`
- [x] Verify assets (JS, CSS) still load correctly
- [x] Verify API routes still work (`/api/status`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)