### PR TITLE
fix: prevent empty duration strings when saving post upload script settings

### DIFF
--- a/frontend/src/lib/components/settings/PostUploadScriptSection.svelte
+++ b/frontend/src/lib/components/settings/PostUploadScriptSection.svelte
@@ -66,7 +66,9 @@ async function savePostUploadScriptSettings() {
 			throw new Error("Timeout is required");
 		}
 
+		// Preserve existing fields and only update the ones managed by this UI
 		currentConfig.post_upload_script = {
+			...currentConfig.post_upload_script,
 			enabled: enabled,
 			command: command.trim(),
 			timeout: timeout.trim(),


### PR DESCRIPTION
## Summary
- Fix config save error: `time: invalid duration ""` when saving post upload script settings
- Frontend now preserves existing config fields instead of overwriting entire object
- Backend YAML Duration unmarshaller now handles empty strings gracefully (matching JSON behavior)
- Removed debug logging code from config.go

## Test plan
- [x] Open settings, configure post upload script, save - should succeed without duration parsing error
- [x] Verify existing post upload script settings are preserved after save
- [x] Verify config file contains valid duration values for all Duration fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)