### PR TITLE
feat: Add missing i18n translations for dashboard components

### DIFF
--- a/frontend/src/lib/components/dashboard/FileExplorerModal.svelte
+++ b/frontend/src/lib/components/dashboard/FileExplorerModal.svelte
@@ -108,7 +108,7 @@ function handlePathInputKeydown(event: KeyboardEvent) {
 
 async function importSelectedFiles() {
   if (selectedFiles.size === 0) {
-    toastStore.error($t("common.messages.error"), "No files selected");
+    toastStore.error($t("common.messages.error"), $t("dashboard.file_explorer.no_files_selected"));
     return;
   }
 
@@ -116,10 +116,10 @@ async function importSelectedFiles() {
   try {
     const filePaths = Array.from(selectedFiles);
     await apiClient.importFiles(filePaths);
-    
+
     toastStore.success(
       $t("dashboard.file_explorer.import_success"),
-      `Successfully added ${filePaths.length} file${filePaths.length !== 1 ? 's' : ''} to queue`
+      $t("dashboard.file_explorer.import_success_description", { values: { count: filePaths.length } })
     );
     
     // Clear selection and close modal
@@ -216,15 +216,15 @@ onMount(() => {
             class="btn btn-ghost btn-sm"
             onclick={goBack}
             disabled={pathHistory.length === 0}
-            title="Go back"
+            title={$t('dashboard.file_explorer.go_back_tooltip')}
           >
             <ArrowLeft class="w-4 h-4" />
           </button>
-          
+
           <button
             class="btn btn-ghost btn-sm"
             onclick={goHome}
-            title="Go to root"
+            title={$t('dashboard.file_explorer.go_home_tooltip')}
           >
             <Home class="w-4 h-4" />
           </button>
@@ -236,16 +236,16 @@ onMount(() => {
               class="input input-bordered input-sm w-full"
               bind:value={pathInput}
               onkeydown={handlePathInputKeydown}
-              placeholder="Enter path (e.g., /home/user/documents)"
+              placeholder={$t('dashboard.file_explorer.path_placeholder')}
             />
           </div>
-          
+
           <button
             class="btn btn-primary btn-sm"
             onclick={() => navigateToPath(pathInput)}
             disabled={loading}
           >
-            Go
+            {$t('dashboard.file_explorer.go_button')}
           </button>
         </div>
 
@@ -254,13 +254,13 @@ onMount(() => {
           <div class="flex items-center gap-2">
             {#if hasSelectedFiles}
               <span class="text-sm text-base-content/70">
-                {selectedFileCount} item{selectedFileCount !== 1 ? 's' : ''} selected
+                {$t('dashboard.file_explorer.items_selected', { values: { count: selectedFileCount } })}
               </span>
               <button
                 class="btn btn-ghost btn-xs"
                 onclick={clearSelection}
               >
-                Clear
+                {$t('dashboard.file_explorer.clear_selection')}
               </button>
             {/if}
 
@@ -269,12 +269,12 @@ onMount(() => {
               onclick={selectAll}
               disabled={fileManagerData.length === 0}
             >
-              Select All
+              {$t('dashboard.file_explorer.select_all')}
             </button>
           </div>
-          
+
           <div class="text-sm text-base-content/70">
-            Current: {currentPath}
+            {$t('dashboard.file_explorer.current_path', { values: { path: currentPath } })}
           </div>
         </div>
       </div>
@@ -285,17 +285,17 @@ onMount(() => {
           <div class="absolute inset-0 bg-base-100/80 flex items-center justify-center z-10">
             <div class="flex items-center gap-2">
               <Loader class="w-6 h-6 animate-spin text-primary" />
-              <span class="text-base-content/70">Loading...</span>
+              <span class="text-base-content/70">{$t('dashboard.file_explorer.loading')}</span>
             </div>
           </div>
         {/if}
-        
+
         <div class="h-full overflow-y-auto">
           {#if fileManagerData.length === 0 && !loading}
             <div class="flex items-center justify-center h-full text-base-content/50">
               <div class="text-center">
                 <div class="text-6xl mb-4">📁</div>
-                <p>This directory is empty</p>
+                <p>{$t('dashboard.file_explorer.empty_directory')}</p>
               </div>
             </div>
           {:else}
@@ -331,7 +331,10 @@ onMount(() => {
                     <div class="font-medium truncate">{item.id.split('/').pop()}</div>
                     <div class="text-sm text-base-content/70 flex items-center gap-2 mt-1">
                       <span>
-                        {item.type === "file" ? `${(item.size / 1024).toFixed(1)} KB` : "Folder"}
+                        {item.type === "file"
+                          ? $t('dashboard.file_explorer.file_size_kb', { values: { size: (item.size / 1024).toFixed(1) } })
+                          : $t('dashboard.file_explorer.folder_type')
+                        }
                       </span>
                       <span>•</span>
                       <span>{item.date.toLocaleDateString()}</span>
@@ -364,20 +367,20 @@ onMount(() => {
       <div class="flex items-center justify-between p-4 border-t border-base-300 bg-base-50">
         <div class="text-sm text-base-content/70">
           {#if hasSelectedFiles}
-            {selectedFileCount} item{selectedFileCount !== 1 ? 's' : ''} selected
+            {$t('dashboard.file_explorer.items_selected', { values: { count: selectedFileCount } })}
           {:else}
-            {fileManagerData.length} item{fileManagerData.length !== 1 ? 's' : ''}
+            {$t('dashboard.file_explorer.item_count_footer', { values: { count: fileManagerData.length } })}
           {/if}
         </div>
-        
+
         <div class="flex gap-2">
           <button
             class="btn btn-ghost"
             onclick={onClose}
           >
-            Cancel
+            {$t('dashboard.file_explorer.cancel_button')}
           </button>
-          
+
           <button
             class="btn btn-primary"
             onclick={importSelectedFiles}
@@ -385,10 +388,10 @@ onMount(() => {
           >
             {#if importing}
               <Loader class="w-4 h-4 animate-spin" />
-              Adding to Queue...
+              {$t('dashboard.file_explorer.adding_to_queue')}
             {:else}
               <Upload class="w-4 h-4" />
-              Add {selectedFileCount > 0 ? selectedFileCount : ''} Item{selectedFileCount !== 1 ? 's' : ''} to Queue
+              {$t('dashboard.file_explorer.add_to_queue_button', { values: { count: selectedFileCount } })}
             {/if}
           </button>
         </div>

--- a/frontend/src/lib/components/dashboard/ProgressSection.svelte
+++ b/frontend/src/lib/components/dashboard/ProgressSection.svelte
@@ -4,7 +4,7 @@ import { t } from "$lib/i18n";
 import { isUploading, runningJobs } from "$lib/stores/app";
 import { toastStore } from "$lib/stores/toast";
 import { formatSpeed, formatTime, formatFileSize } from "$lib/utils";
-import { ChartPie, CheckCircle, Play, X, Upload, Package, Check, Pause } from "lucide-svelte";
+import { ChartPie, CheckCircle, Play, X, Upload, Package, Check } from "lucide-svelte";
 import { onMount, onDestroy } from "svelte";
 
 // Use the generated types from Wails
@@ -177,7 +177,7 @@ function cancelUpload(jobID: string) {
           <!-- Individual Progress Indicators -->
           {#if job.progress.length > 0}
             <div class="space-y-4">
-              <h4 class="text-md font-medium text-base-content">Active Tasks</h4>
+              <h4 class="text-md font-medium text-base-content">{$t('dashboard.progress.active_tasks')}</h4>
               {#each job.progress as progressState}
                 {@const IconComponent = getProgressIcon(progressState?.Type)}
                 <div class="bg-base-100 rounded-xl border border-base-300 p-4">
@@ -230,32 +230,32 @@ function cancelUpload(jobID: string) {
                   {#if !progressState?.IsPaused}
                     <div class="grid grid-cols-2 gap-4 text-xs text-base-content/70">
                       <div>
-                        <span class="block">Elapsed</span>
+                        <span class="block">{$t('dashboard.progress.elapsed')}</span>
                         <span class="font-medium text-base-content">{formatTime((progressState?.SecondsSince || 0) * 1000)}</span>
                       </div>
                       <div>
-                        <span class="block">Remaining</span>
+                        <span class="block">{$t('dashboard.progress.remaining')}</span>
                         <span class="font-medium text-base-content">{formatTime((progressState?.SecondsLeft || 0) * 1000)}</span>
                       </div>
-                      
+
                       <!-- Show speed for upload tasks -->
                       {#if (progressState.Type === "uploading" || progressState.Type === "checking") && progressState?.KBsPerSecond}
                         <div>
-                          <span class="block">Speed</span>
+                          <span class="block">{$t('dashboard.progress.speed')}</span>
                           <span class="font-medium text-base-content">{formatSpeed((progressState.KBsPerSecond || 0) * 1024)}</span>
                         </div>
                       {/if}
-                      
+
                       <!-- Hide current/total for par2 generation, show as formatted bytes for uploads -->
                       {#if progressState.Type !== "par2_generation"}
                         <div>
-                          <span class="block">Current</span>
+                          <span class="block">{$t('dashboard.progress.current')}</span>
                           <span class="font-medium text-base-content">
                               {formatFileSize(progressState.CurrentBytes)}
                           </span>
                         </div>
                         <div>
-                          <span class="block">Total</span>
+                          <span class="block">{$t('dashboard.progress.total')}</span>
                           <span class="font-medium text-base-content">
                               {formatFileSize(progressState.Max)}
                           </span>
@@ -267,13 +267,13 @@ function cancelUpload(jobID: string) {
                     {#if progressState.Type !== "par2_generation"}
                       <div class="grid grid-cols-2 gap-4 text-xs text-base-content/70">
                         <div>
-                          <span class="block">Current</span>
+                          <span class="block">{$t('dashboard.progress.current')}</span>
                           <span class="font-medium text-base-content">
                               {formatFileSize(progressState.CurrentBytes)}
                           </span>
                         </div>
                         <div>
-                          <span class="block">Total</span>
+                          <span class="block">{$t('dashboard.progress.total')}</span>
                           <span class="font-medium text-base-content">
                               {formatFileSize(progressState.Max)}
                           </span>

--- a/frontend/src/lib/locales/en/dashboard.json
+++ b/frontend/src/lib/locales/en/dashboard.json
@@ -72,7 +72,7 @@
 			"resume_processing": "Resume Processing",
 			"paused": "Processing Paused",
 			"paused_description": "All upload tasks have been paused",
-			"resumed": "Processing Resumed", 
+			"resumed": "Processing Resumed",
 			"resumed_description": "Upload tasks have been resumed",
 			"job_title": "Job {jobId}",
 			"cancel_upload": "Cancel Upload",
@@ -85,7 +85,13 @@
 			"details": "Details",
 			"last_update": "Last Update",
 			"no_upload_title": "No upload in progress",
-			"no_upload_description": "Click \"Start Upload\" to begin processing the queue"
+			"no_upload_description": "Click \"Start Upload\" to begin processing the queue",
+			"active_tasks": "Active Tasks",
+			"elapsed": "Elapsed",
+			"remaining": "Remaining",
+			"speed": "Speed",
+			"current": "Current",
+			"total": "Total"
 		},
 		"stats": {
 			"title": "Statistics",
@@ -125,7 +131,25 @@
 		"job_failed": "Upload failed: {fileName}",
 		"file_explorer": {
 			"title": "Add Files from Server to Queue",
-			"import_success": "Files added to queue successfully"
+			"import_success": "Files added to queue successfully",
+			"no_files_selected": "No files selected",
+			"import_success_description": "Successfully added {count} {count, plural, =1 {file} other {files}} to queue",
+			"go_back_tooltip": "Go back",
+			"go_home_tooltip": "Go to root",
+			"path_placeholder": "Enter path (e.g., /home/user/documents)",
+			"go_button": "Go",
+			"items_selected": "{count} {count, plural, =1 {item} other {items}} selected",
+			"clear_selection": "Clear",
+			"select_all": "Select All",
+			"current_path": "Current: {path}",
+			"loading": "Loading...",
+			"empty_directory": "This directory is empty",
+			"file_size_kb": "{size} KB",
+			"folder_type": "Folder",
+			"cancel_button": "Cancel",
+			"adding_to_queue": "Adding to Queue...",
+			"add_to_queue_button": "Add {count} {count, plural, =1 {Item} other {Items}} to Queue",
+			"item_count_footer": "{count} {count, plural, =1 {item} other {items}}"
 		},
 		"provider": {
 			"title": "Provider Status",

--- a/frontend/src/lib/locales/es/dashboard.json
+++ b/frontend/src/lib/locales/es/dashboard.json
@@ -87,7 +87,13 @@
 			"details": "Detalles",
 			"last_update": "Última Actualización",
 			"no_upload_title": "No hay carga en progreso",
-			"no_upload_description": "Haga clic en \"Iniciar Carga\" para comenzar a procesar la cola"
+			"no_upload_description": "Haga clic en \"Iniciar Carga\" para comenzar a procesar la cola",
+			"active_tasks": "Tareas Activas",
+			"elapsed": "Transcurrido",
+			"remaining": "Restante",
+			"speed": "Velocidad",
+			"current": "Actual",
+			"total": "Total"
 		},
 		"stats": {
 			"title": "Estadísticas",
@@ -127,7 +133,25 @@
 		"job_failed": "Subida fallida: {fileName}",
 		"file_explorer": {
 			"title": "Agregar Archivos del Servidor a la Cola",
-			"import_success": "Archivos agregados a la cola exitosamente"
+			"import_success": "Archivos agregados a la cola exitosamente",
+			"no_files_selected": "No se han seleccionado archivos",
+			"import_success_description": "Se {count, plural, =1 {agregó} other {agregaron}} {count} {count, plural, =1 {archivo} other {archivos}} a la cola correctamente",
+			"go_back_tooltip": "Volver",
+			"go_home_tooltip": "Ir a raíz",
+			"path_placeholder": "Ingrese la ruta (ej., /home/usuario/documentos)",
+			"go_button": "Ir",
+			"items_selected": "{count} {count, plural, =1 {elemento seleccionado} other {elementos seleccionados}}",
+			"clear_selection": "Limpiar",
+			"select_all": "Seleccionar Todo",
+			"current_path": "Actual: {path}",
+			"loading": "Cargando...",
+			"empty_directory": "Este directorio está vacío",
+			"file_size_kb": "{size} KB",
+			"folder_type": "Carpeta",
+			"cancel_button": "Cancelar",
+			"adding_to_queue": "Agregando a la Cola...",
+			"add_to_queue_button": "Agregar {count} {count, plural, =1 {Elemento} other {Elementos}} a la Cola",
+			"item_count_footer": "{count} {count, plural, =1 {elemento} other {elementos}}"
 		},
 		"provider": {
 			"title": "Estado de los Proveedores",

--- a/frontend/src/lib/locales/fr/dashboard.json
+++ b/frontend/src/lib/locales/fr/dashboard.json
@@ -86,7 +86,13 @@
 			"details": "Détails",
 			"last_update": "Dernière Mise à Jour",
 			"no_upload_title": "Aucun téléchargement en cours",
-			"no_upload_description": "Cliquez sur \"Démarrer le Téléchargement\" pour commencer le traitement de la file d'attente"
+			"no_upload_description": "Cliquez sur \"Démarrer le Téléchargement\" pour commencer le traitement de la file d'attente",
+			"active_tasks": "Tâches Actives",
+			"elapsed": "Écoulé",
+			"remaining": "Restant",
+			"speed": "Vitesse",
+			"current": "Actuel",
+			"total": "Total"
 		},
 		"stats": {
 			"title": "Statistiques",
@@ -126,7 +132,25 @@
 		"job_failed": "Échec du téléchargement: {fileName}",
 		"file_explorer": {
 			"title": "Ajouter des Fichiers du Serveur à la File",
-			"import_success": "Fichiers ajoutés à la file avec succès"
+			"import_success": "Fichiers ajoutés à la file avec succès",
+			"no_files_selected": "Aucun fichier sélectionné",
+			"import_success_description": "{count} {count, plural, =1 {fichier ajouté} other {fichiers ajoutés}} à la file avec succès",
+			"go_back_tooltip": "Retour",
+			"go_home_tooltip": "Aller à la racine",
+			"path_placeholder": "Entrez le chemin (ex., /home/utilisateur/documents)",
+			"go_button": "Aller",
+			"items_selected": "{count} {count, plural, =1 {élément sélectionné} other {éléments sélectionnés}}",
+			"clear_selection": "Effacer",
+			"select_all": "Tout Sélectionner",
+			"current_path": "Actuel : {path}",
+			"loading": "Chargement...",
+			"empty_directory": "Ce répertoire est vide",
+			"file_size_kb": "{size} Ko",
+			"folder_type": "Dossier",
+			"cancel_button": "Annuler",
+			"adding_to_queue": "Ajout à la File...",
+			"add_to_queue_button": "Ajouter {count} {count, plural, =1 {Élément} other {Éléments}} à la File",
+			"item_count_footer": "{count} {count, plural, =1 {élément} other {éléments}}"
 		},
 		"provider": {
 			"title": "État du Fournisseur",


### PR DESCRIPTION
## Summary
Adds comprehensive internationalization support for dashboard components that previously had hardcoded English text.

## Changes
- **ProgressSection.svelte**: Translated 6 progress metric labels (Elapsed, Remaining, Speed, Current, Total, Active Tasks)
- **FileExplorerModal.svelte**: Translated 14 UI strings including navigation controls, status messages, and action buttons
- **Translation files**: Added all keys to English, Spanish, and French with proper ICU pluralization

## Implementation Details
- Uses `svelte-i18n` with ICU message format for pluralization: `{count, plural, =1 {singular} other {plural}}`
- All parameterized translations use the `values` object format: `$t('key', { values: { param } })`
- Follows existing project patterns from WatcherStatus component
- Supports dynamic language switching between EN/ES/FR

## Testing
- ✅ All translation keys added to 3 language files
- ✅ TypeScript errors resolved
- ✅ Proper pluralization for singular/plural forms
- ✅ Parameters correctly passed for dynamic content

## Test Plan
1. Start dev server and test language switcher
2. Verify progress section displays during upload
3. Test file explorer modal in web mode
4. Check pluralization with 1 item vs multiple items
5. Verify French translations don't break layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)