### PR TITLE
fix: add folder upload as single NZB support in web mode

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -422,6 +422,15 @@ export class UnifiedClient {
 
 		if (this._environment === "web") {
 			const client = await getWebClient();
+
+			// Check if this is a folder upload (files have webkitRelativePath)
+			const firstFile = files[0] as File & { webkitRelativePath?: string };
+			if (firstFile?.webkitRelativePath) {
+				// Use folder upload endpoint to preserve directory structure
+				return client.uploadFolderFiles(files, onProgress, setRequest);
+			}
+
+			// Regular file upload
 			return client.uploadFiles(files, onProgress, setRequest);
 		}
 


### PR DESCRIPTION
## Summary
- Adds support for uploading folders as a single NZB in web mode via the "Add Folder" button
- Preserves folder structure during upload using webkitRelativePath
- Simplifies folder processing to add root folder as single queue entry

## Test plan
- [x] Run web server: `cd cmd/web && go run .`
- [x] Open browser to web UI
- [x] Click "Add Folder" button
- [x] Select a folder with multiple files/subfolders
- [x] Verify queue shows single entry with folder name
- [x] Verify NZB contains all nested files

🤖 Generated with [Claude Code](https://claude.com/claude-code)