### PR TITLE
feat: add log download button and display slog attributes in logs UI

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -494,6 +494,22 @@ export class UnifiedClient {
 		throw new Error("No client available");
 	}
 
+	async downloadLogFile(): Promise<void> {
+		await this.initialize();
+
+		if (this._environment === "wails") {
+			const client = await getWailsClient();
+			return client.App.DownloadLogFile();
+		}
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.downloadLogs();
+		}
+
+		throw new Error("No client available");
+	}
+
 	// Event Handling
 	async on(event: string, callback: EventCallback): Promise<void> {
 		await this.initialize();

--- a/frontend/src/lib/api/web-client.ts
+++ b/frontend/src/lib/api/web-client.ts
@@ -455,6 +455,31 @@ export class WebClient {
 	}> {
 		return this.post("/filesystem/import", { filePaths });
 	}
+
+	// Log download
+	async downloadLogs(): Promise<void> {
+		const response = await fetch(`${API_BASE}/logs/download`);
+
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
+
+		// Create a blob from the response and trigger download
+		const blob = await response.blob();
+		const url = window.URL.createObjectURL(blob);
+		const filename =
+			response.headers
+				.get("Content-Disposition")
+				?.match(/filename="(.+?)"/)?.[1] ||
+			`postie-${new Date().toISOString().split("T")[0]}.log`;
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = filename;
+		document.body.appendChild(a);
+		a.click();
+		window.URL.revokeObjectURL(url);
+		document.body.removeChild(a);
+	}
 }
 
 // Singleton instance

--- a/frontend/src/lib/locales/en/common.json
+++ b/frontend/src/lib/locales/en/common.json
@@ -87,5 +87,11 @@
 			"failed_to_cancel_item": "Failed to cancel item"
 		},
 		"app_name": "Postie"
+	},
+	"logs": {
+		"download": "Download",
+		"download_success": "Log file downloaded",
+		"download_success_description": "The log file has been saved successfully",
+		"download_error": "Failed to download log file"
 	}
 }

--- a/frontend/src/lib/locales/es/common.json
+++ b/frontend/src/lib/locales/es/common.json
@@ -87,5 +87,11 @@
 			"item_cancelled": "Elemento cancelado",
 			"failed_to_cancel_item": "Error al cancelar el elemento"
 		}
+	},
+	"logs": {
+		"download": "Descargar",
+		"download_success": "Archivo de registro descargado",
+		"download_success_description": "El archivo de registro se ha guardado correctamente",
+		"download_error": "Error al descargar el archivo de registro"
 	}
 }

--- a/frontend/src/lib/locales/fr/common.json
+++ b/frontend/src/lib/locales/fr/common.json
@@ -105,5 +105,11 @@
 			"configuration_saved_description": "Votre configuration a été sauvegardée avec succès !",
 			"configuration_save_failed": "Échec de la sauvegarde de la configuration"
 		}
+	},
+	"logs": {
+		"download": "Télécharger",
+		"download_success": "Fichier journal téléchargé",
+		"download_success_description": "Le fichier journal a été enregistré avec succès",
+		"download_error": "Échec du téléchargement du fichier journal"
 	}
 }

--- a/frontend/src/lib/stores/logs.ts
+++ b/frontend/src/lib/stores/logs.ts
@@ -4,6 +4,7 @@ export type LogEntry = {
 	timestamp: Date;
 	level: "log" | "info" | "warn" | "error" | "debug";
 	message: string;
+	attributes?: Record<string, unknown>;
 };
 
 export const frontendLogs = writable<LogEntry[]>([]);

--- a/frontend/src/lib/wailsjs/go/backend/App.d.ts
+++ b/frontend/src/lib/wailsjs/go/backend/App.d.ts
@@ -20,6 +20,8 @@ export function DebugQueueItem(arg1:string):Promise<Record<string, any>>;
 
 export function DiscardPendingConfig():Promise<void>;
 
+export function DownloadLogFile():Promise<void>;
+
 export function DownloadNZB(arg1:string):Promise<void>;
 
 export function GetAppStatus():Promise<backend.AppStatus>;

--- a/frontend/src/lib/wailsjs/go/backend/App.js
+++ b/frontend/src/lib/wailsjs/go/backend/App.js
@@ -30,6 +30,10 @@ export function DiscardPendingConfig() {
   return window['go']['backend']['App']['DiscardPendingConfig']();
 }
 
+export function DownloadLogFile() {
+  return window['go']['backend']['App']['DownloadLogFile']();
+}
+
 export function DownloadNZB(arg1) {
   return window['go']['backend']['App']['DownloadNZB'](arg1);
 }

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -13,11 +13,11 @@ export namespace backend {
 	    configValid: boolean;
 	    needsConfiguration: boolean;
 	    version: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new AppStatus(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.hasConfig = source["hasConfig"];


### PR DESCRIPTION
## Summary

- Add a download button to the logs page that allows users to save the full log file locally
- Enhance the logs viewer to display custom slog attributes (like file, folder, size) as inline badges

## Changes

### Log Download Feature
- **Backend (Go)**: Add `DownloadLogFile()` method with native save dialog for desktop app
- **Web Server**: Add `/api/logs/download` endpoint for web mode
- **Frontend**: Add `downloadLogFile()` to API client with browser download support
- **UI**: Add download button with loading spinner next to refresh button

### Log Attributes Display
- Parse custom slog attributes from JSON log entries (file, folder, size, error, etc.)
- Display attributes as inline ghost badges next to log messages
- Format numbers with locale formatting for better readability

### Internationalization
- Add translations for download feature in English, Spanish, and French

## Test plan

- [x] Test download button in desktop app (should open native save dialog)
- [x] Test download button in web mode (should trigger browser download)
- [x] Verify log attributes display correctly as badges
- [x] Test with logs containing various attribute types (strings, numbers, booleans)
- [x] Verify translations work for all supported languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)