### PR TITLE
fix: add CSS drop target properties for Windows drag and drop

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,6 +167,8 @@ func main() {
 		DragAndDrop: &options.DragAndDrop{
 			EnableFileDrop:     true,
 			DisableWebViewDrop: true,
+			CSSDropProperty:    "--wails-drop-target",
+			CSSDropValue:       "drop",
 		},
 		Logger: logger.NewDefaultLogger(),
 		OnStartup: func(ctx context.Context) {


### PR DESCRIPTION
## Summary
- Fixed drag and drop not working in Windows binary by adding missing CSS drop target properties to Wails configuration
- The visual overlay appeared but dropping folders did nothing because Wails couldn't detect valid drop zones

## Test plan
- [x] Build Windows binary with `wails build -platform windows/amd64`
- [x] Drag a folder onto the application window
- [x] Verify the visual overlay appears (already worked)
- [x] Verify dropping triggers the file processing and adds files to queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)