### PR TITLE
feat: add dev build workflow for main branch merges

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,251 @@
+name: Dev Build
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/test
+
+  build-frontend:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache frontend dependencies
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: frontend-deps-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            frontend-deps-${{ runner.os }}-
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: Extract version info
+        id: version
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          echo "version=dev-$COMMIT" >> $GITHUB_OUTPUT
+          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          npm_package_version: ${{ steps.version.outputs.version }}
+          GIT_COMMIT: ${{ steps.version.outputs.commit }}
+        run: bun run build
+
+      - name: Upload frontend build
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build/
+          retention-days: 7
+
+  build-gui-windows:
+    runs-on: windows-latest
+    needs: test
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Install Bun
+        run: npm install -g bun
+
+      - name: Build Windows GUI
+        run: wails build -platform windows/amd64 -ldflags="-extldflags=-static"
+        env:
+          CGO_ENABLED: 1
+
+      - name: Upload Windows GUI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: postie-gui-windows-amd64
+          path: build/bin
+          retention-days: 7
+
+  build-gui-macos:
+    runs-on: macos-latest
+    needs: test
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Install Bun
+        run: npm install -g bun
+
+      - name: Build macOS GUI
+        run: wails build -platform darwin/universal
+        env:
+          CGO_ENABLED: 1
+
+      - name: Upload macOS GUI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: postie-gui-macos-universal
+          path: build/bin
+          retention-days: 7
+
+  build-image-amd64:
+    runs-on: ubuntu-latest
+    needs: [test, build-frontend]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push AMD64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile.ci
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-amd64-temp
+          cache-from: type=gha,scope=dev-amd64
+          cache-to: type=gha,mode=max,scope=dev-amd64
+          provenance: false
+          sbom: false
+
+  build-image-arm64:
+    runs-on: ubuntu-latest
+    needs: [test, build-frontend]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile.ci
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-arm64-temp
+          cache-from: type=gha,scope=dev-arm64
+          cache-to: type=gha,mode=max,scope=dev-arm64
+          provenance: false
+          sbom: false
+
+  create-docker-manifest:
+    runs-on: ubuntu-latest
+    needs: [build-image-amd64, build-image-arm64]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-platform manifest
+        run: |
+          AMD64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-amd64-temp"
+          ARM64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-arm64-temp"
+
+          echo "Creating dev manifest from:"
+          echo "  AMD64: $AMD64_IMAGE"
+          echo "  ARM64: $ARM64_IMAGE"
+
+          # Create and push dev manifest
+          docker manifest create \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev \
+            $AMD64_IMAGE \
+            $ARM64_IMAGE
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+
+      - name: Clean up temporary tags
+        run: |
+          docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-amd64-temp || true
+          docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-arm64-temp || true


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow triggered on every push to main
- Build and push multi-arch Docker image (`ghcr.io/javi11/postie:dev`) with amd64 + arm64 support
- Build Windows and macOS GUI as downloadable workflow artifacts (7-day retention)

## Test plan
- [ ] Merge to main and verify workflow runs successfully
- [ ] Verify Docker `dev` image is pushed to GHCR with multi-arch support
- [ ] Verify GUI artifacts are downloadable from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)