### PR TITLE
fix: update Dockerfile.ci to use Go 1.25

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -3,7 +3,7 @@
 # syntax=docker/dockerfile:1.11
 
 # Backend build stage with native arch support
-FROM golang:1.24-alpine AS backend-builder
+FROM golang:1.25-alpine AS backend-builder
 
 # Install build dependencies including sqlite with cache mount
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
## Summary
- Update Go version in Dockerfile.ci from 1.24 to 1.25
- Fixes dev build workflow failure due to go.mod requiring Go 1.25.1

## Test plan
- [ ] Verify Docker build succeeds with the dev-build workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)