### PR TITLE
fix: close PAR2 command pipe to prevent resource leak on Windows

### DIFF
--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -226,6 +226,7 @@ func (p *Par2CmdExecutor) Create(ctx context.Context, files []fileinfo.FileInfo)
 				return nil, fmt.Errorf("failed to get stderr pipe for parpar: %w", err)
 			}
 		}
+		defer cmdReader.Close() // Ensure pipe is closed to prevent resource leak on Windows
 
 		scanner := bufio.NewScanner(cmdReader)
 		scanner.Split(scanLines)
@@ -418,6 +419,7 @@ func (p *Par2CmdExecutor) CreateInDirectory(ctx context.Context, files []fileinf
 				return nil, fmt.Errorf("failed to get stderr pipe for parpar: %w", err)
 			}
 		}
+		defer cmdReader.Close() // Ensure pipe is closed to prevent resource leak on Windows
 
 		scanner := bufio.NewScanner(cmdReader)
 		scanner.Split(scanLines)


### PR DESCRIPTION
## Summary
- Fix resource leak in PAR2 command execution that causes "482 too many connections" errors on Windows
- Add `defer cmdReader.Close()` in both `Create()` and `CreateInDirectory()` methods

## Root Cause
The stdout/stderr pipe from PAR2 commands was never explicitly closed. On Windows, unclosed pipes accumulate file handles that prevent proper NNTP connection pool cleanup, eventually hitting the NNTP server's connection limit.

## Test plan
- [x] All PAR2 tests pass
- [x] Project builds successfully
- [x] Manual test on Windows with PAR2-enabled uploads on 300-400MB files

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)