### PR TITLE
feat: add version and git commit display to dashboard header

### DIFF
--- a/frontend/src/lib/components/dashboard/DashboardHeader.svelte
+++ b/frontend/src/lib/components/dashboard/DashboardHeader.svelte
@@ -189,9 +189,17 @@ async function handleFolderUpload() {
   <div class="card-body">
     <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
       <div class="space-y-2">
-        <h1 class="text-3xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-          {$t("dashboard.header.title")}
-        </h1>
+        <div class="flex items-center gap-3">
+          <h1 class="text-3xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
+            {$t("dashboard.header.title")}
+          </h1>
+          <span class="text-sm text-base-content/50">
+            v{__APP_VERSION__}
+            {#if __GIT_COMMIT__ !== "unknown"}
+              <span class="text-base-content/40">({__GIT_COMMIT__.slice(0, 7)})</span>
+            {/if}
+          </span>
+        </div>
         <p class="text-lg text-base-content/70">
           {$t("dashboard.header.description")}
         </p>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __GIT_COMMIT__: string;
+declare const __GITHUB_URL__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,11 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
 	plugins: [sveltekit(), tailwindcss()],
+	define: {
+		__APP_VERSION__: JSON.stringify(process.env.npm_package_version || "0.0.0"),
+		__GIT_COMMIT__: JSON.stringify(process.env.GIT_COMMIT || "unknown"),
+		__GITHUB_URL__: JSON.stringify("https://github.com/javi11/postie"),
+	},
 	resolve: {
 		alias: {
 			$lib: "./src/lib",


### PR DESCRIPTION
## Summary
- Add compile-time version variables (`__APP_VERSION__`, `__GIT_COMMIT__`, `__GITHUB_URL__`) via Vite's define option
- Add TypeScript declarations for the global variables
- Display version and shortened git commit hash next to the dashboard title

## Test plan
- [x] Run `bun run dev` in frontend and verify version displays (will show `v0.0.0` in dev)
- [x] Build with `GIT_COMMIT=$(git rev-parse HEAD) bun run build` and verify commit hash appears
- [x] Verify TypeScript has no errors related to the new global variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)