### PR TITLE
chore: update Go version to 1.26 in module and workflows

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25.1' # Pinned version
+        go-version: '1.26' # Pinned version
     - name: Go info
       shell: bash
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.25.1"
+  GO_VERSION: '1.26'
 
 jobs:
   coverage:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26
 
       # checkout
       - name: Checkout
@@ -297,7 +297,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26
 
       # checkout
       - name: Checkout
@@ -357,7 +357,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -397,7 +397,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -3,7 +3,7 @@
 # syntax=docker/dockerfile:1.11
 
 # Backend build stage with native arch support
-FROM golang:1.25-alpine AS backend-builder
+FROM golang:1.26-alpine AS backend-builder
 
 # Install build dependencies including sqlite with cache mount
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/javi11/postie
 
-go 1.25.1
+go 1.26
 
 require (
 	github.com/andybalholm/brotli v1.2.0


### PR DESCRIPTION
- Updated go.mod to require Go 1.26
- Updated GitHub Actions workflows to use Go 1.26 for setup
- Updated Dockerfile.ci to use Go 1.26-alpine

This ensures compatibility with the latest Go features and improvements.