### PR TITLE
feat: add two-section server UI (Upload Pool / Verify Pool) to setup wizard

### DIFF
--- a/frontend/src/lib/components/setup/ServerSetupStep.svelte
+++ b/frontend/src/lib/components/setup/ServerSetupStep.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import NntpServerManager from "$lib/components/NntpServerManager.svelte";
+import { t } from "$lib/i18n";
 import { backend } from "$lib/wailsjs/go/models";
+import { Upload, ShieldCheck } from "lucide-svelte";
 
 interface Props {
 	servers?: backend.ServerData[];
@@ -10,40 +12,129 @@ interface Props {
 
 let { servers = $bindable([]), onupdate, onvalidationchange }: Props = $props();
 
-function handleServerUpdate(updatedServers: any[]) {
-	// Convert from our generic server format to backend.ServerData
-	servers = updatedServers.map(server => {
-		const serverData = new backend.ServerData();
-		serverData.host = server.host;
-		serverData.port = server.port;
-		serverData.username = server.username || "";
-		serverData.password = server.password || "";
-		serverData.maxConnections = server.max_connections || 10;
-		serverData.ssl = server.ssl || false;
-		return serverData;
-	});
-	
+// Inject a default upload server synchronously so NntpServerManager
+// initializes with it immediately on first render
+if (servers.length === 0) {
+	const sd = new backend.ServerData();
+	sd.host = "";
+	sd.port = 119;
+	sd.ssl = false;
+	sd.username = "";
+	sd.password = "";
+	sd.maxConnections = 10;
+	sd.role = "upload";
+	servers = [sd];
 	onupdate?.({ servers });
 }
 
-// Convert servers to the format expected by NntpServerManager
-let managedServers = $derived(servers.map(server => ({
-	host: server.host,
-	port: server.port,
-	username: server.username,
-	password: server.password,
-	max_connections: server.maxConnections || 10,
-	ssl: server.ssl,
-	max_connection_idle_time_in_seconds: 300,
-	max_connection_ttl_in_seconds: 3600,
-	insecure_ssl: false,
-	inflight: 10,
-})));
+function toNntpFormat(s: backend.ServerData) {
+	return {
+		host: s.host,
+		port: s.port,
+		ssl: s.ssl || false,
+		username: s.username || "",
+		password: s.password || "",
+		max_connections: s.maxConnections || 10,
+		inflight: 10,
+		insecure_ssl: false,
+		max_connection_idle_time_in_seconds: 300,
+		max_connection_ttl_in_seconds: 3600,
+		role: s.role || "upload",
+	};
+}
+
+function toServerData(s: any, role: string): backend.ServerData {
+	const sd = new backend.ServerData();
+	sd.host = s.host || "";
+	sd.port = s.port || 119;
+	sd.ssl = s.ssl || false;
+	sd.username = s.username || "";
+	sd.password = s.password || "";
+	sd.maxConnections = s.max_connections || 10;
+	sd.role = role;
+	return sd;
+}
+
+let uploadManagedServers = $derived(
+	servers.filter(s => (s.role || "upload") !== "verify").map(s => toNntpFormat(s))
+);
+
+let verifyManagedServers = $derived(
+	servers.filter(s => s.role === "verify").map(s => toNntpFormat(s))
+);
+
+function handleUploadUpdate(updated: any[]) {
+	servers = [
+		...updated.map(s => toServerData(s, "upload")),
+		...servers.filter(s => s.role === "verify").map(s => toServerData(s, "verify")),
+	];
+	onupdate?.({ servers });
+}
+
+function handleVerifyUpdate(updated: any[]) {
+	servers = [
+		...servers.filter(s => (s.role || "upload") !== "verify").map(s => toServerData(s, "upload")),
+		...updated.map(s => toServerData(s, "verify")),
+	];
+	onupdate?.({ servers });
+}
+
+// Only upload pool validation gates the "Next" button
+function handleUploadValidation(data: { hasValidServers: boolean }) {
+	onvalidationchange(data);
+}
 </script>
 
-<NntpServerManager
-	servers={managedServers}
-	onupdate={handleServerUpdate}
-	onvalidationchange={onvalidationchange}
-	variant="setup"
-/>
+<div class="space-y-6">
+  <!-- Upload Pool -->
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body space-y-4">
+      <div class="flex items-center gap-3">
+        <Upload class="w-5 h-5 text-primary" />
+        <div>
+          <h2 class="text-lg font-semibold text-base-content">
+            {$t("settings.server.upload_pool_title")}
+          </h2>
+          <p class="text-sm text-base-content/60">
+            {$t("settings.server.upload_pool_description")}
+          </p>
+        </div>
+      </div>
+
+      <NntpServerManager
+        servers={uploadManagedServers}
+        onupdate={handleUploadUpdate}
+        onvalidationchange={handleUploadValidation}
+        variant="settings"
+        restrictedRole="upload"
+      />
+    </div>
+  </div>
+
+  <!-- Verify Pool -->
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body space-y-4">
+      <div class="flex items-center gap-3">
+        <ShieldCheck class="w-5 h-5 text-secondary" />
+        <div>
+          <h2 class="text-lg font-semibold text-base-content">
+            {$t("settings.server.verify_pool_title")}
+            <span class="badge badge-ghost badge-sm ml-2">
+              {$t("settings.server.verify_pool_optional")}
+            </span>
+          </h2>
+          <p class="text-sm text-base-content/60">
+            {$t("settings.server.verify_pool_description")}
+          </p>
+        </div>
+      </div>
+
+      <NntpServerManager
+        servers={verifyManagedServers}
+        onupdate={handleVerifyUpdate}
+        variant="settings"
+        restrictedRole="verify"
+      />
+    </div>
+  </div>
+</div>

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -368,17 +368,31 @@
 			},
 			"validation": {
 				"cannot_disable_last": "Cannot disable the last active provider. At least one provider must remain enabled.",
-				"cannot_set_all_check_only": "Cannot set all providers to check-only. At least one provider must be available for posting."
+				"cannot_set_all_verify": "Cannot set all providers to verify-only. At least one upload server must remain.",
+				"upload_host_conflict": "All upload servers must use the same provider host. Using multiple providers for upload simultaneously is considered spam in Usenet."
 			},
-			"check_only": "Check Only",
-			"check_only_description": "Use this provider only for verifying uploaded articles, not for posting",
-			"check_only_enabled_description": "This provider will only verify articles, not post them",
-			"check_only_badge": "Verify Only",
+			"role": "Server Role",
+			"role_upload": "Upload",
+			"role_upload_description": "Post articles to Usenet via this provider",
+			"role_verify": "Verify Only",
+			"role_verify_description": "Use only for verifying uploaded articles (STAT checks), not for posting",
+			"role_verify_badge": "Verify Only",
 			"validation_errors": {
 				"host_required": "Server {number}: Host is required",
 				"port_invalid": "Server {number}: Valid port number is required (1-65535)"
 			},
-			"tip": "<strong>Tip:</strong> Configure multiple servers for better redundancy and upload speeds. The application will automatically distribute uploads across all configured servers.",
+			"tip": "<strong>Tip:</strong> Add multiple accounts from the <strong>same provider</strong> to maximize upload bandwidth. Use \"Verify Only\" servers from other providers to confirm articles have propagated across the Usenet backbone.",
+			"upload_pool_title": "Upload Pool",
+			"upload_pool_description": "Add multiple accounts from the same provider to maximize upload bandwidth",
+			"upload_pool_provider_label": "Provider",
+			"upload_pool_provider_description": "Host and port are shared across all upload accounts",
+			"verify_pool_title": "Verify Pool",
+			"verify_pool_optional": "Optional",
+			"verify_pool_description": "Use servers from other providers to confirm articles have propagated across the Usenet backbone",
+			"verify_pool_empty_notice": "No verify servers configured — the upload pool will be used for article verification",
+			"add_account": "Add Account",
+			"add_verify_server": "Add Verify Server",
+			"account_number": "Account {number}",
 			"proxy": {
 				"section_title": "Proxy Settings",
 				"enable_proxy": "Use SOCKS5 Proxy",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -407,17 +407,31 @@
 			},
 			"validation": {
 				"cannot_disable_last": "No se puede deshabilitar el último proveedor activo. Al menos un proveedor debe permanecer habilitado.",
-				"cannot_set_all_check_only": "No se pueden configurar todos los proveedores como solo verificación. Al menos un proveedor debe estar disponible para publicar."
+				"cannot_set_all_verify": "No se pueden configurar todos los proveedores como solo verificación. Al menos un servidor de carga debe permanecer.",
+				"upload_host_conflict": "Todos los servidores de carga deben usar el mismo proveedor. Usar múltiples proveedores para carga simultáneamente se considera spam en Usenet."
 			},
-			"check_only": "Solo Verificación",
-			"check_only_description": "Usar este proveedor solo para verificar artículos cargados, no para publicar",
-			"check_only_enabled_description": "Este proveedor solo verificará artículos, no los publicará",
-			"check_only_badge": "Solo Verificar",
+			"role": "Rol del Servidor",
+			"role_upload": "Carga",
+			"role_upload_description": "Publicar artículos en Usenet a través de este proveedor",
+			"role_verify": "Solo Verificación",
+			"role_verify_description": "Usar solo para verificar artículos cargados (verificaciones STAT), no para publicar",
+			"role_verify_badge": "Solo Verificar",
 			"validation_errors": {
 				"host_required": "Servidor {number}: Se requiere host",
 				"port_invalid": "Servidor {number}: Se requiere un número de puerto válido (1-65535)"
 			},
 			"tip": "<strong>Consejo:</strong> Configure múltiples servidores para mejor redundancia y velocidades de carga. La aplicación distribuirá automáticamente las cargas entre todos los servidores configurados.",
+			"upload_pool_title": "Pool de Carga",
+			"upload_pool_description": "Agregue múltiples cuentas del mismo proveedor para maximizar el ancho de banda de carga",
+			"upload_pool_provider_label": "Proveedor",
+			"upload_pool_provider_description": "El host y el puerto son compartidos por todas las cuentas de carga",
+			"verify_pool_title": "Pool de Verificación",
+			"verify_pool_optional": "Opcional",
+			"verify_pool_description": "Use servidores de otros proveedores para confirmar que los artículos se han propagado por la red Usenet",
+			"verify_pool_empty_notice": "Sin servidores de verificación configurados — el pool de carga se usará para verificar artículos",
+			"add_account": "Agregar Cuenta",
+			"add_verify_server": "Agregar Servidor de Verificación",
+			"account_number": "Cuenta {number}",
 			"proxy": {
 				"section_title": "Configuración de Proxy",
 				"enable_proxy": "Usar Proxy SOCKS5",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -405,17 +405,31 @@
 			},
 			"validation": {
 				"cannot_disable_last": "Impossible de désactiver le dernier fournisseur actif. Au moins un fournisseur doit rester activé.",
-				"cannot_set_all_check_only": "Impossible de configurer tous les fournisseurs en vérification uniquement. Au moins un fournisseur doit être disponible pour la publication."
+				"cannot_set_all_verify": "Impossible de configurer tous les fournisseurs en vérification uniquement. Au moins un serveur d'envoi doit rester.",
+				"upload_host_conflict": "Tous les serveurs d'envoi doivent utiliser le même fournisseur. Utiliser plusieurs fournisseurs pour l'envoi simultané est considéré comme du spam sur Usenet."
 			},
-			"check_only": "Vérification Uniquement",
-			"check_only_description": "Utiliser ce fournisseur uniquement pour vérifier les articles téléchargés, pas pour publier",
-			"check_only_enabled_description": "Ce fournisseur vérifiera uniquement les articles, il ne les publiera pas",
-			"check_only_badge": "Vérif. Seule",
+			"role": "Rôle du Serveur",
+			"role_upload": "Envoi",
+			"role_upload_description": "Publier des articles sur Usenet via ce fournisseur",
+			"role_verify": "Vérification Seule",
+			"role_verify_description": "Utiliser uniquement pour vérifier les articles téléchargés (vérifications STAT), pas pour publier",
+			"role_verify_badge": "Vérif. Seule",
 			"validation_errors": {
 				"host_required": "Serveur {number} : L'hôte est requis",
 				"port_invalid": "Serveur {number} : Un numéro de port valide est requis (1-65535)"
 			},
 			"tip": "<strong>Astuce :</strong> Configurez plusieurs serveurs pour une meilleure redondance et des vitesses de téléchargement. L'application distribuera automatiquement les téléchargements entre tous les serveurs configurés.",
+			"upload_pool_title": "Pool d'Envoi",
+			"upload_pool_description": "Ajoutez plusieurs comptes du même fournisseur pour maximiser la bande passante d'envoi",
+			"upload_pool_provider_label": "Fournisseur",
+			"upload_pool_provider_description": "L'hôte et le port sont partagés entre tous les comptes d'envoi",
+			"verify_pool_title": "Pool de Vérification",
+			"verify_pool_optional": "Optionnel",
+			"verify_pool_description": "Utilisez des serveurs d'autres fournisseurs pour confirmer la propagation des articles sur le réseau Usenet",
+			"verify_pool_empty_notice": "Aucun serveur de vérification configuré — le pool d'envoi sera utilisé pour la vérification des articles",
+			"add_account": "Ajouter un Compte",
+			"add_verify_server": "Ajouter un Serveur de Vérification",
+			"account_number": "Compte {number}",
 			"proxy": {
 				"section_title": "Paramètres du Proxy",
 				"enable_proxy": "Utiliser un Proxy SOCKS5",

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -366,17 +366,31 @@
             },
             "validation": {
                 "cannot_disable_last": "Son aktif sağlayıcı devre dışı bırakılamaz. En az bir sağlayıcı etkin kalmalıdır.",
-                "cannot_set_all_check_only": "Tüm sağlayıcılar yalnızca kontrol amaçlı olarak ayarlanamaz. En az bir sağlayıcı gönderim için uygun olmalıdır."
+                "cannot_set_all_verify": "Tüm sağlayıcılar yalnızca doğrulama olarak ayarlanamaz. En az bir yükleme sunucusu kalmalıdır.",
+                "upload_host_conflict": "Tüm yükleme sunucuları aynı sağlayıcıyı kullanmalıdır. Eş zamanlı yükleme için birden fazla sağlayıcı kullanmak Usenet'te spam olarak kabul edilir."
             },
-            "check_only": "Yalnızca Kontrol",
-            "check_only_description": "Bu sağlayıcıyı yalnızca yüklenen makaleleri doğrulamak için kullanın, gönderim için değil",
-            "check_only_enabled_description": "Bu sağlayıcı yalnızca makaleleri doğrulayacak, göndermeyecek",
-            "check_only_badge": "Yalnızca Doğrula",
+            "role": "Sunucu Rolü",
+            "role_upload": "Yükleme",
+            "role_upload_description": "Bu sağlayıcı aracılığıyla Usenet'e makale yayınla",
+            "role_verify": "Yalnızca Doğrulama",
+            "role_verify_description": "Yalnızca yüklenen makaleleri doğrulamak için kullanın (STAT kontrolleri), yayınlamak için değil",
+            "role_verify_badge": "Yalnızca Doğrula",
             "validation_errors": {
                 "host_required": "Sunucu {number}: Ana Bilgisayar gerekli",
                 "port_invalid": "Sunucu {number}: Geçerli port numarası gerekli (1-65535)"
             },
             "tip": "<strong>İpucu:</strong> Daha iyi yedeklilik ve yükleme hızları için birden fazla sunucu yapılandırın. Uygulama, yüklemeleri yapılandırılmış tüm sunuculara otomatik olarak dağıtacaktır.",
+            "upload_pool_title": "Yükleme Havuzu",
+            "upload_pool_description": "Yükleme bant genişliğini artırmak için aynı sağlayıcıdan birden fazla hesap ekleyin",
+            "upload_pool_provider_label": "Sağlayıcı",
+            "upload_pool_provider_description": "Ana bilgisayar ve port tüm yükleme hesapları arasında paylaşılır",
+            "verify_pool_title": "Doğrulama Havuzu",
+            "verify_pool_optional": "İsteğe Bağlı",
+            "verify_pool_description": "Makalelerin Usenet ağına yayıldığını doğrulamak için diğer sağlayıcıların sunucularını kullanın",
+            "verify_pool_empty_notice": "Doğrulama sunucusu yapılandırılmadı — makale doğrulaması için yükleme havuzu kullanılacak",
+            "add_account": "Hesap Ekle",
+            "add_verify_server": "Doğrulama Sunucusu Ekle",
+            "account_number": "Hesap {number}",
             "proxy": {
                 "section_title": "Proxy Ayarları",
                 "enable_proxy": "SOCKS5 Proxy Kullan",

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -264,6 +264,7 @@ export namespace backend {
 	    password: string;
 	    ssl: boolean;
 	    maxConnections: number;
+	    role: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new ServerData(source);
@@ -277,6 +278,7 @@ export namespace backend {
 	        this.password = source["password"];
 	        this.ssl = source["ssl"];
 	        this.maxConnections = source["maxConnections"];
+	        this.role = source["role"] ?? "";
 	    }
 	}
 	export class SetupWizardData {
@@ -641,6 +643,7 @@ export namespace config {
 	    max_connection_ttl_in_seconds: number;
 	    insecure_ssl: boolean;
 	    enabled?: boolean;
+	    role: string;
 	    check_only?: boolean;
 	    inflight: number;
 	    proxy_url?: string;
@@ -661,6 +664,7 @@ export namespace config {
 	        this.max_connection_ttl_in_seconds = source["max_connection_ttl_in_seconds"];
 	        this.insecure_ssl = source["insecure_ssl"];
 	        this.enabled = source["enabled"];
+	        this.role = source["role"] || "upload";
 	        this.check_only = source["check_only"];
 	        this.inflight = source["inflight"];
 	        this.proxy_url = source["proxy_url"];

--- a/internal/backend/processor.go
+++ b/internal/backend/processor.go
@@ -123,9 +123,9 @@ func (a *App) initializePostCheckWorker() {
 		return
 	}
 
-	checkPool := a.poolManager.GetCheckPool()
+	checkPool := a.poolManager.GetVerifyPool()
 	if checkPool == nil {
-		slog.Warn("No check pool available, skipping deferred check worker initialization")
+		slog.Warn("No verify pool available, skipping deferred check worker initialization")
 		return
 	}
 

--- a/internal/mocks/pool.go
+++ b/internal/mocks/pool.go
@@ -40,21 +40,35 @@ func (m *MockPoolManager) EXPECT() *MockPoolManagerMockRecorder {
 	return m.recorder
 }
 
-// GetCheckPool mocks base method.
-func (m *MockPoolManager) GetCheckPool() pool.NNTPClient {
+// GetUploadPool mocks base method.
+func (m *MockPoolManager) GetUploadPool() pool.NNTPClient {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCheckPool")
+	ret := m.ctrl.Call(m, "GetUploadPool")
 	ret0, _ := ret[0].(pool.NNTPClient)
 	return ret0
 }
 
-// GetCheckPool indicates an expected call of GetCheckPool.
-func (mr *MockPoolManagerMockRecorder) GetCheckPool() *gomock.Call {
+// GetUploadPool indicates an expected call of GetUploadPool.
+func (mr *MockPoolManagerMockRecorder) GetUploadPool() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckPool", reflect.TypeOf((*MockPoolManager)(nil).GetCheckPool))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploadPool", reflect.TypeOf((*MockPoolManager)(nil).GetUploadPool))
 }
 
-// GetPool mocks base method.
+// GetVerifyPool mocks base method.
+func (m *MockPoolManager) GetVerifyPool() pool.NNTPClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVerifyPool")
+	ret0, _ := ret[0].(pool.NNTPClient)
+	return ret0
+}
+
+// GetVerifyPool indicates an expected call of GetVerifyPool.
+func (mr *MockPoolManagerMockRecorder) GetVerifyPool() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVerifyPool", reflect.TypeOf((*MockPoolManager)(nil).GetVerifyPool))
+}
+
+// GetPool mocks base method (deprecated alias for GetUploadPool).
 func (m *MockPoolManager) GetPool() pool.NNTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPool")
@@ -66,4 +80,18 @@ func (m *MockPoolManager) GetPool() pool.NNTPClient {
 func (mr *MockPoolManagerMockRecorder) GetPool() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPool", reflect.TypeOf((*MockPoolManager)(nil).GetPool))
+}
+
+// GetCheckPool mocks base method (deprecated alias for GetVerifyPool).
+func (m *MockPoolManager) GetCheckPool() pool.NNTPClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCheckPool")
+	ret0, _ := ret[0].(pool.NNTPClient)
+	return ret0
+}
+
+// GetCheckPool indicates an expected call of GetCheckPool.
+func (mr *MockPoolManagerMockRecorder) GetCheckPool() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckPool", reflect.TypeOf((*MockPoolManager)(nil).GetCheckPool))
 }

--- a/internal/poster/poster_test.go
+++ b/internal/poster/poster_test.go
@@ -137,7 +137,7 @@ func TestPost(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    checkCfg,
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -197,7 +197,7 @@ func TestPost(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    checkCfg,
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -250,7 +250,7 @@ func TestPost(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    checkCfg,
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -304,8 +304,8 @@ func TestPost(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    checkCfg,
-			pool:        mockPool,
-			checkPool:   mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -359,8 +359,8 @@ func TestPost(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    checkCfg,
-			pool:        mockPool,
-			checkPool:   mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -393,8 +393,8 @@ func TestPost(t *testing.T) {
 
 		// Test checkArticle method directly
 		p := &poster{
-			pool:      mockPool,
-			checkPool: mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:     &Stats{StartTime: time.Now()},
 		}
 		defer p.Close()
@@ -433,8 +433,8 @@ func TestPost(t *testing.T) {
 		}).AnyTimes()
 
 		p := &poster{
-			pool:      mockPool,
-			checkPool: mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:     &Stats{StartTime: time.Now()},
 		}
 		defer p.Close()
@@ -491,8 +491,8 @@ func TestPost(t *testing.T) {
 		mockPool.EXPECT().Stat(gomock.Any(), gomock.Any()).Return(&nntppool.StatResult{}, nil)
 
 		p := &poster{
-			pool:        mockPool,
-			checkPool:   mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mocks.NewMockJobProgress(ctrl),
@@ -544,8 +544,8 @@ func TestPost(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    createTestPostCheckConfig(),
-			pool:        mockPool,
-			checkPool:   mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mocks.NewMockJobProgress(ctrl),
@@ -609,7 +609,7 @@ func TestPostArticle(t *testing.T) {
 		mockPool.EXPECT().PostYenc(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nntppool.PostResult{}, nil)
 
 		p := &poster{
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mocks.NewMockJobProgress(ctrl),
@@ -659,7 +659,7 @@ func TestPostArticle(t *testing.T) {
 		}).AnyTimes()
 
 		p := &poster{
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mocks.NewMockJobProgress(ctrl),
@@ -703,7 +703,7 @@ func TestPostArticle(t *testing.T) {
 		mockPool.EXPECT().PostYenc(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("post failed"))
 
 		p := &poster{
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mocks.NewMockJobProgress(ctrl),
@@ -744,8 +744,8 @@ func TestCheckArticle(t *testing.T) {
 		mockPool.EXPECT().Stat(ctx, "test@example.com").Return(&nntppool.StatResult{}, nil)
 
 		p := &poster{
-			pool:      mockPool,
-			checkPool: mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:     &Stats{StartTime: time.Now()},
 		}
 
@@ -773,8 +773,8 @@ func TestCheckArticle(t *testing.T) {
 		mockPool.EXPECT().Stat(ctx, "test@example.com").Return(nil, errors.New("not found"))
 
 		p := &poster{
-			pool:      mockPool,
-			checkPool: mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:     &Stats{StartTime: time.Now()},
 		}
 
@@ -1017,8 +1017,8 @@ func TestPostIntegration(t *testing.T) {
 		p := &poster{
 			cfg:         cfg,
 			checkCfg:    checkCfg,
-			pool:        mockPool,
-			checkPool:   mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -1072,7 +1072,7 @@ func TestPostLoop_Basic(t *testing.T) {
 		p := &poster{
 			cfg:         createTestConfig(),
 			checkCfg:    createTestPostCheckConfig(),
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -1135,7 +1135,7 @@ func TestPostLoop_Basic(t *testing.T) {
 		mockProgress.EXPECT().GetID().Return(uuid.New()).AnyTimes()
 
 		p := &poster{
-			pool:        mockPool,
+			uploadPool:  mockPool,
 			stats:       &Stats{StartTime: time.Now()},
 			throttle:    NewThrottle(1024*1024, time.Second),
 			jobProgress: mockJobProgress,
@@ -1184,8 +1184,8 @@ func TestCheckLoop_Basic(t *testing.T) {
 		mockPool.EXPECT().Stat(ctx, "test@example.com").Return(&nntppool.StatResult{}, nil)
 
 		p := &poster{
-			pool:      mockPool,
-			checkPool: mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:     &Stats{StartTime: time.Now()},
 		}
 
@@ -1212,8 +1212,8 @@ func TestCheckLoop_Basic(t *testing.T) {
 		mockPool.EXPECT().Stat(ctx, "test@example.com").Return(nil, errors.New("article not found"))
 
 		p := &poster{
-			pool:      mockPool,
-			checkPool: mockPool, // Use same pool for checking
+			uploadPool:  mockPool,
+			verifyPool:  mockPool, // Use same pool for checking
 			stats:     &Stats{StartTime: time.Now()},
 		}
 
@@ -1285,7 +1285,7 @@ func createMockNNTPClient(ctrl *gomock.Controller) *mocks.MockNNTPClient {
 // createMockPoolManager creates a mock pool manager for testing using the generated mock
 func createMockPoolManager(ctrl *gomock.Controller, nntpClient pool.NNTPClient) *mocks.MockPoolManager {
 	mockPoolManager := mocks.NewMockPoolManager(ctrl)
-	mockPoolManager.EXPECT().GetPool().Return(nntpClient).AnyTimes()
-	mockPoolManager.EXPECT().GetCheckPool().Return(nntpClient).AnyTimes()
+	mockPoolManager.EXPECT().GetUploadPool().Return(nntpClient).AnyTimes()
+	mockPoolManager.EXPECT().GetVerifyPool().Return(nntpClient).AnyTimes()
 	return mockPoolManager
 }


### PR DESCRIPTION
## Summary

- Adds `Role string` to the `ServerData` Go struct and updates `SetupWizardComplete` to persist the role onto each `ServerConfig` (empty role defaults to `upload`); validates that ≥1 upload server is always present before saving
- Adds `role: string` to the `ServerData` TypeScript Wails binding (`frontend/src/lib/wailsjs/go/models.ts`)
- Rewrites `ServerSetupStep.svelte` to show two `NntpServerManager` sections — **Upload Pool** and **Verify Pool** — matching the layout already used in the settings page

## Test plan

- [x] Open setup wizard → Server step: two sections visible (Upload Pool / Verify Pool)
- [x] Upload Pool shows shared-provider row; can add multiple accounts
- [x] Verify Pool can be left empty (info notice shown by NntpServerManager)
- [x] "Next" button requires ≥1 validated upload server; verify pool is ignored for gating
- [x] Complete wizard → open Settings → Server: saved servers appear in correct pools with correct roles
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)