### PR TITLE
fix: suppress misleading ERROR logs on first start

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -192,6 +192,13 @@ func (a *App) applyConfigChanges(configData *config.ConfigData) error {
 		return err
 	}
 
+	// Initialize queue if not yet created (e.g. after setup wizard on first start)
+	if a.queue == nil {
+		if err := a.initializeQueue(); err != nil {
+			slog.Error("Failed to initialize queue after config change", "error", err)
+		}
+	}
+
 	if err := a.initializeProcessor(); err != nil {
 		slog.Error("Failed to re-initialize processor after config change", "error", err)
 	}


### PR DESCRIPTION
## Summary

- Skip queue/processor/watcher initialization in `Startup()` when `firstStart` is true — these components have no config to work with and only produced noisy ERROR logs while the setup wizard is displayed
- Downgrade the expected default-config load failure from `slog.Error` to `slog.Debug` — on first start the default config intentionally has no servers, so validation failing is expected, not an error
- Add queue initialization in `applyConfigChanges()` when `a.queue == nil`, ensuring the queue is created after the setup wizard completes and `SaveConfig` is called

## Test plan

- [ ] Delete config file and restart app — verify no ERROR logs appear, only INFO; setup wizard displays correctly
- [ ] Complete setup wizard — verify queue, processor, and watcher initialize successfully after wizard completion
- [ ] Normal restart (existing config) — verify all components initialize as before with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)