### PR TITLE
fix: replace wget with curl in Docker healthchecks

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,15 +20,7 @@ services:
       - PGID=1000
     restart: unless-stopped
     healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:8080/live",
-        ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/live"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,15 +15,7 @@ services:
       - PGID=1000
     restart: unless-stopped
     healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:8080/live",
-        ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/live"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,7 +96,7 @@ VOLUME ["/config", "/watch", "/output"]
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/live || exit 1
+    CMD curl -f http://localhost:8080/live || exit 1
 
 LABEL org.opencontainers.image.source="https://github.com/javi11/postie"
 LABEL build_version="version: Build-date:- ${VERSION} ${BUILD_DATE}"

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -75,7 +75,7 @@ VOLUME ["/config", "/watch", "/output"]
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/live || exit 1
+    CMD curl -f http://localhost:8080/live || exit 1
 
 # Labels
 LABEL org.opencontainers.image.source="https://github.com/javi11/postie"


### PR DESCRIPTION
## Summary

- Replaces `wget --no-verbose --tries=1 --spider` with `curl -f` in all Docker healthcheck definitions
- Affects `docker/Dockerfile`, `docker/Dockerfile.ci`, `docker-compose.yml`, and `docker-compose.dev.yml`
- The base image `ghcr.io/linuxserver/baseimage-ubuntu:jammy` ships with `curl` but not `wget`, causing containers to be marked unhealthy on startup

## Test plan

- [ ] Build the dev image: `docker compose -f docker-compose.dev.yml up --build`
- [ ] Check container health: `docker inspect postie-dev --format='{{.State.Health.Status}}'`
- [ ] Confirm status shows `healthy` within 35 seconds (start_period 5s + interval 30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)