### PR TITLE
fix: improve theme selector layout in setup wizard WelcomeStep

### DIFF
--- a/frontend/src/lib/components/setup/WelcomeStep.svelte
+++ b/frontend/src/lib/components/setup/WelcomeStep.svelte
@@ -16,46 +16,46 @@ import { t } from "$lib/i18n";
 	</div>
 
 	<!-- Language and Theme Controls - Modern daisyUI Cards -->
-	<div class="w-full max-w-2xl space-y-8">
+	<div class="w-full max-w-3xl space-y-4">
 		<h3 class="text-2xl font-semibold text-base-content text-center mb-8">
 			{$t("setup.welcome.preferences_title")}
 		</h3>
-		
-		<div class="grid grid-cols-1 sm:grid-cols-2 gap-8">
-			<!-- Language Selector -->
-			<div class="card bg-base-100/90 backdrop-blur-sm shadow-xl border border-base-300/60">
-				<div class="card-body text-center space-y-4">
-					<div class="avatar">
-						<div class="w-12 h-12 bg-primary rounded-lg mx-auto mb-4 flex items-center justify-center">
-							<svg class="w-6 h-6 text-primary-content" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"></path>
-							</svg>
-						</div>
+
+		<!-- Language Selector - compact horizontal card -->
+		<div class="card bg-base-100/90 backdrop-blur-sm shadow-xl border border-base-300/60">
+			<div class="card-body py-4">
+				<div class="flex items-center gap-4">
+					<div class="w-10 h-10 bg-primary rounded-lg flex items-center justify-center shrink-0">
+						<svg class="w-5 h-5 text-primary-content" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"></path>
+						</svg>
 					</div>
-					<h4 class="card-title text-lg justify-center">{$t("setup.welcome.language_title")}</h4>
-					<p class="text-sm text-base-content/70 mb-4">{$t("setup.welcome.language_description")}</p>
-					<div class="flex justify-center">
+					<div class="flex-1 min-w-0">
+						<h4 class="font-semibold text-base-content">{$t("setup.welcome.language_title")}</h4>
+						<p class="text-sm text-base-content/70">{$t("setup.welcome.language_description")}</p>
+					</div>
+					<div class="ml-auto shrink-0">
 						<LanguageSwitcher />
 					</div>
 				</div>
 			</div>
+		</div>
 
-			<!-- Theme Selector -->
-			<div class="card bg-base-100/90 backdrop-blur-sm shadow-xl border border-base-300/60">
-				<div class="card-body text-center space-y-4">
-					<div class="avatar">
-						<div class="w-12 h-12 bg-secondary rounded-lg mx-auto mb-4 flex items-center justify-center">
-							<svg class="w-6 h-6 text-secondary-content" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
-							</svg>
-						</div>
+		<!-- Theme Selector - full-width card -->
+		<div class="card bg-base-100/90 backdrop-blur-sm shadow-xl border border-base-300/60">
+			<div class="card-body">
+				<div class="flex items-center gap-4 mb-4">
+					<div class="w-10 h-10 bg-secondary rounded-lg flex items-center justify-center shrink-0">
+						<svg class="w-5 h-5 text-secondary-content" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
+						</svg>
 					</div>
-					<h4 class="card-title text-lg justify-center">{$t("setup.welcome.theme_title")}</h4>
-					<p class="text-sm text-base-content/70 mb-4">{$t("setup.welcome.theme_description")}</p>
-					<div class="flex justify-center">
-						<ThemeSwitcher />
+					<div>
+						<h4 class="font-semibold text-base-content">{$t("setup.welcome.theme_title")}</h4>
+						<p class="text-sm text-base-content/70">{$t("setup.welcome.theme_description")}</p>
 					</div>
 				</div>
+				<ThemeSwitcher />
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- Replace two-column grid layout with a vertical stack (`space-y-4`) in `WelcomeStep.svelte`
- Language selector is now a compact horizontal card with icon/text on the left and the dropdown on the right
- Theme selector gets a full-width card so the theme grid has sufficient horizontal space without overflow
- Widen container from `max-w-2xl` to `max-w-3xl` for better breathing room

## Test plan

- [ ] Open setup wizard and navigate to the Welcome step
- [ ] Verify language dropdown is visible and aligned correctly in the compact horizontal card
- [ ] Verify theme grid (light/dark themes) renders fully without overflow or clipping
- [ ] Test at various viewport widths to confirm responsive behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)