### PR TITLE
feat: add configurable MinFileAge to prevent uploading in-progress files

### DIFF
--- a/frontend/src/lib/components/settings/WatcherSection.svelte
+++ b/frontend/src/lib/components/settings/WatcherSection.svelte
@@ -25,6 +25,7 @@ let { config = $bindable() }: Props = $props();
 let watchDirectory = $state("");
 let enabled = $state(config.watcher?.enabled ?? false);
 let checkInterval = $state(config.watcher?.check_interval || "5m");
+let minFileAge = $state(config.watcher?.min_file_age || "60s");
 let sizeThreshold = $state(config.watcher?.size_threshold || 104857600); // 100MB
 let minFileSize = $state(config.watcher?.min_file_size || 1048576); // 1MB
 let deleteOriginalFile = $state(config.watcher?.delete_original_file ?? false);
@@ -39,6 +40,13 @@ let initialized = $state(false);
 const checkIntervalPresets = [
   { label: "30s", value: 30, unit: "s" },
   { label: "2m", value: 2, unit: "m" },
+  { label: "5m", value: 5, unit: "m" },
+  { label: "10m", value: 10, unit: "m" },
+];
+
+const minFileAgePresets = [
+  { label: "30s", value: 30, unit: "s" },
+  { label: "1m", value: 1, unit: "m" },
   { label: "5m", value: 5, unit: "m" },
   { label: "10m", value: 10, unit: "m" },
 ];
@@ -73,6 +81,7 @@ $effect(() => {
 		config.watcher.watch_directory = watchDirectory;
 		config.watcher.enabled = enabled;
 		config.watcher.check_interval = checkInterval;
+		config.watcher.min_file_age = minFileAge;
 		config.watcher.size_threshold = sizeThreshold;
 		config.watcher.min_file_size = minFileSize;
 		config.watcher.delete_original_file = deleteOriginalFile;
@@ -111,6 +120,7 @@ $effect(() => {
 			// Initialize all local state from config
 			enabled = config.watcher?.enabled ?? false;
 			checkInterval = config.watcher?.check_interval || "5m";
+		minFileAge = config.watcher?.min_file_age || "60s";
 			sizeThreshold = config.watcher?.size_threshold || 104857600;
 			minFileSize = config.watcher?.min_file_size || 1048576;
 			deleteOriginalFile = config.watcher?.delete_original_file ?? false;
@@ -183,6 +193,7 @@ async function saveWatcherSettings() {
     currentConfig.watcher.size_threshold = config.watcher.size_threshold ?? currentConfig.watcher.size_threshold;
     currentConfig.watcher.min_file_size = config.watcher.min_file_size ?? currentConfig.watcher.min_file_size;
     currentConfig.watcher.check_interval = config.watcher.check_interval || currentConfig.watcher.check_interval;
+    currentConfig.watcher.min_file_age = config.watcher.min_file_age || currentConfig.watcher.min_file_age;
     currentConfig.watcher.delete_original_file = config.watcher.delete_original_file ?? currentConfig.watcher.delete_original_file;
     currentConfig.watcher.single_nzb_per_folder = config.watcher.single_nzb_per_folder ?? currentConfig.watcher.single_nzb_per_folder;
     
@@ -294,6 +305,14 @@ async function saveWatcherSettings() {
               description={$t('settings.watcher.check_interval_description')}
               presets={checkIntervalPresets}
               id="check-interval"
+            />
+
+            <DurationInput
+              bind:value={minFileAge}
+              label={$t('settings.watcher.min_file_age')}
+              description={$t('settings.watcher.min_file_age_description')}
+              presets={minFileAgePresets}
+              id="min-file-age"
             />
 
             <SizeInput

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -145,6 +145,8 @@
 			"watch_directory_description": "Directory where new files will be monitored for automatic upload. Processed files will be moved to the global output directory.",
 			"check_interval": "Check Interval",
 			"check_interval_description": "How often to scan for new files",
+			"min_file_age": "Min File Age",
+			"min_file_age_description": "Minimum time since last modification before a file is eligible for upload. Prevents uploading files still being written (e.g. slow copies, torrents).",
 			"size_threshold": "Size Threshold",
 			"size_threshold_description": "Minimum accumulated size before batch processing",
 			"min_file_size": "Min File Size",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -140,6 +140,8 @@
 			"watch_directory_description": "Directorio donde se monitorearán nuevos archivos para carga automática. Los archivos procesados se moverán al directorio de salida global.",
 			"check_interval": "Intervalo de Verificación",
 			"check_interval_description": "Frecuencia para buscar nuevos archivos",
+			"min_file_age": "Antigüedad Mínima del Archivo",
+			"min_file_age_description": "Tiempo mínimo desde la última modificación antes de que un archivo sea elegible para carga. Evita subir archivos que aún se están escribiendo (p. ej. copias lentas, torrents).",
 			"size_threshold": "Umbral de Tamaño",
 			"size_threshold_description": "Tamaño acumulado mínimo antes del procesamiento por lotes",
 			"min_file_size": "Tamaño Mínimo de Archivo",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -140,6 +140,8 @@
 			"watch_directory_description": "Répertoire où les nouveaux fichiers seront surveillés pour le téléchargement automatique. Les fichiers traités seront déplacés vers le répertoire de sortie global.",
 			"check_interval": "Intervalle de Vérification",
 			"check_interval_description": "Fréquence de recherche de nouveaux fichiers",
+			"min_file_age": "Âge Minimum du Fichier",
+			"min_file_age_description": "Durée minimale depuis la dernière modification avant qu'un fichier soit éligible à l'envoi. Évite d'envoyer des fichiers encore en cours d'écriture (ex. copies lentes, torrents).",
 			"size_threshold": "Seuil de Taille",
 			"size_threshold_description": "Taille accumulée minimale avant le traitement par lot",
 			"min_file_size": "Taille Minimale de Fichier",

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -145,6 +145,8 @@
             "watch_directory_description": "Otomatik yükleme için yeni dosyaların izleneceği dizin. İşlenen dosyalar genel çıktı dizinine taşınacaktır.",
             "check_interval": "Kontrol Aralığı",
             "check_interval_description": "Yeni dosyaların ne sıklıkla taranacağı",
+            "min_file_age": "Minimum Dosya Yaşı",
+            "min_file_age_description": "Bir dosyanın yüklenmeye uygun sayılması için son değişiklikten bu yana geçmesi gereken minimum süre. Hâlâ yazılmakta olan dosyaların (ör. yavaş kopyalar, torrentler) yüklenmesini önler.",
             "size_threshold": "Boyut Eşiği",
             "size_threshold_description": "Toplu işlemden önceki minimum birikmiş boyut",
             "min_file_size": "Min Dosya Boyutu",

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -427,11 +427,12 @@ export namespace config {
 	    delete_original_file: boolean;
 	    single_nzb_per_folder: boolean;
 	    follow_symlinks: boolean;
-	
+	    min_file_age: string;
+
 	    static createFrom(source: any = {}) {
 	        return new WatcherConfig(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.enabled = source["enabled"];
@@ -444,6 +445,7 @@ export namespace config {
 	        this.delete_original_file = source["delete_original_file"];
 	        this.single_nzb_per_folder = source["single_nzb_per_folder"];
 	        this.follow_symlinks = source["follow_symlinks"];
+	        this.min_file_age = source["min_file_age"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,6 +288,10 @@ type WatcherConfig struct {
 	// If false (default), symlinks are skipped to avoid double-counting files and including
 	// files outside the watch directory. Set to true to process symlinks as regular files.
 	FollowSymlinks bool `yaml:"follow_symlinks" json:"follow_symlinks"`
+	// MinFileAge is the minimum time since last modification before a file is eligible for upload.
+	// This prevents uploading files that are still being written to (e.g. slow copies, torrents).
+	// Default: 60s
+	MinFileAge Duration `yaml:"min_file_age" json:"min_file_age"`
 }
 
 type ScheduleConfig struct {
@@ -913,9 +917,10 @@ func GetDefaultConfig() ConfigData {
 			IgnorePatterns:     []string{"*.tmp", "*.part", "*.!ut"},
 			MinFileSize:        1048576, // 1MB
 			CheckInterval:      Duration("5m"),
-			DeleteOriginalFile: false, // Default to keeping original files for safety
-			SingleNzbPerFolder: false, // Default to false for backward compatibility
-			FollowSymlinks:     false, // Default to skipping symlinks to avoid double-counting and external files
+			DeleteOriginalFile: false,    // Default to keeping original files for safety
+			SingleNzbPerFolder: false,    // Default to false for backward compatibility
+			FollowSymlinks:     false,    // Default to skipping symlinks to avoid double-counting and external files
+			MinFileAge:         Duration("60s"), // Default to 60s to ensure files are stable before uploading
 		},
 		NzbCompression: NzbCompressionConfig{
 			Enabled: disabled,


### PR DESCRIPTION
## Summary

Closes #136

- Replaces the hardcoded 2-second file stability check with a configurable `min_file_age` duration field in `WatcherConfig` (default: `60s`)
- Removes the ineffective `canOpenFileExclusively` method (simply opens the file read-only — not exclusive on Linux/macOS, so it never actually blocked anything)
- Adds a `DurationInput` control in the Watcher settings UI, placed next to the existing "Check Interval" field
- Adds translations for all 4 locales (en, es, fr, tr)

## Why

Users with slow network shares, torrent clients writing `.mkv` files, or paused downloads were experiencing uploads of incomplete files because the old 2-second threshold was too short. With `min_file_age=5m`, a file must not have been modified in the last 5 minutes before it is eligible for upload.

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `MinFileAge Duration` to `WatcherConfig`, default `60s` |
| `internal/watcher/watcher.go` | Use `cfg.MinFileAge` in `isFileStable`; remove `canOpenFileExclusively` |
| `internal/watcher/watcher_test.go` | Add `MinFileAge` to test watcher; replace `TestCanOpenFileExclusively` with `TestIsFileStable_MinFileAge` |
| `frontend/src/lib/components/settings/WatcherSection.svelte` | Add `minFileAge` state, presets, sync, and `DurationInput` UI |
| `frontend/src/lib/locales/*/settings.json` | Add `min_file_age` / `min_file_age_description` keys |
| `frontend/src/lib/wailsjs/go/models.ts` | Add `min_file_age: string` to `WatcherConfig` class |

## Test plan

- [x] `go test ./internal/watcher/...` — all tests pass
- [x] `go build ./...` — compiles without errors
- [x] `bun run check` — 0 svelte-check errors/warnings
- [ ] Start app → Watcher settings → new "Min File Age" `DurationInput` visible with presets (30s, 1m, 5m, 10m)
- [ ] Set `min_file_age=10s`, place a file modified <10s ago in watch dir → not queued; wait 10s+ → file gets queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)