### PR TITLE
fix: CLI -d flag now creates one NZB per folder instead of one per file

### DIFF
--- a/cmd/postie/postie.go
+++ b/cmd/postie/postie.go
@@ -95,7 +95,7 @@ It supports configuration via a YAML file and can process multiple files in a di
 		}
 
 		// CLI mode: use config-based folder mode decision (not forced)
-		_, err = poster.Post(ctx, files, dirPath, outputDir, false)
+		_, err = poster.Post(ctx, files, dirPath, outputDir, inputFile == "")
 		return err
 	},
 }


### PR DESCRIPTION
## Summary

- Fixes #129: `postie-cli -d <dir>` was creating one NZB per file instead of one NZB for the entire folder
- Root cause: `poster.Post()` was always called with `forceFolderMode=false`, bypassing the existing folder mode logic
- One-line fix: pass `inputFile == ""` as the folder mode flag, which is `true` when `-d` is used and `false` when `-i` is used

## Test plan

- [ ] Run `postie-cli -d /path/with/multiple/files` — should produce a single NZB for all files
- [ ] Run `postie-cli -i /path/to/single/file` — should still produce one NZB per file
- [ ] Build passes: `go build ./cmd/postie/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)