### PR TITLE
fix: use theme.colors for color swatches in ThemeSwitcher

### DIFF
--- a/frontend/src/lib/components/ThemeSwitcher.svelte
+++ b/frontend/src/lib/components/ThemeSwitcher.svelte
@@ -57,7 +57,7 @@ const darkThemes = $derived(groupedThemes["Dark"] ?? []);
 				>
 					<!-- Color swatches -->
 					<div class="flex gap-0.5 h-5">
-						{#each theme.value as color}
+						{#each theme.colors as color}
 							<span
 								class="flex-1 rounded-sm"
 								style="background-color: {color};"
@@ -94,7 +94,7 @@ const darkThemes = $derived(groupedThemes["Dark"] ?? []);
 				>
 					<!-- Color swatches -->
 					<div class="flex gap-0.5 h-5">
-						{#each theme.value as color}
+						{#each theme.colors as color}
 							<span
 								class="flex-1 rounded-sm"
 								style="background-color: {color};"


### PR DESCRIPTION
## Summary
- Fix color swatches not rendering in the theme selector
- The `{#each}` loops were iterating over `theme.value` (a string like `"cupcake"`), producing individual characters instead of hex colors
- Changed both occurrences (light and dark theme grids) to iterate over `theme.colors` — the correct `[string, string, string, string]` array of hex values

## Test plan
- [ ] Open the theme selector and verify each theme button shows 4 colored horizontal strips above the theme name
- [ ] Verify both light and dark theme sections display color swatches correctly
- [ ] Confirm theme selection still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)