### PR TITLE
fix: guard against nil pool manager in processor initialization (#107)

### DIFF
--- a/internal/backend/processor.go
+++ b/internal/backend/processor.go
@@ -41,6 +41,12 @@ func (a *App) initializeProcessor() error {
 		return nil
 	}
 
+	// Pool manager must be available to process items
+	if a.poolManager == nil {
+		slog.Warn("Pool manager not available (server configuration may be invalid), skipping processor initialization")
+		return nil
+	}
+
 	if a.queue == nil {
 		slog.Warn("Queue not available, skipping processor initialization")
 		return nil

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -214,7 +214,7 @@ func (p *Processor) processNextItem(ctx context.Context) error {
 	}
 
 	if poolManager == nil {
-		slog.WarnContext(ctx, "Pool manager is not available, skipping item processing")
+		slog.WarnContext(ctx, "Pool manager is not available, waiting for server configuration")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes #107 — queue items stuck in pending when the pool manager is unavailable.

- When pool creation fails (e.g. invalid or missing server config), `a.poolManager` stays `nil` but `initializeProcessor` was still creating a processor with a `nil` pool manager
- Every 2 seconds `processNextItem` would log a warning and skip, leaving all queued items stuck forever
- Add an explicit `nil` check in `initializeProcessor` so no useless processor is created; the next call to `initializeProcessor` (triggered by a config save) will properly create it once valid servers are configured
- Improve the warning message in `processor.go` to be more descriptive

## Test plan

- [ ] Start app with no servers configured → no processor is created, no warning spam in logs
- [ ] Add valid servers via Settings → save config → processor starts and pending items are processed
- [ ] Start app with valid servers but a connection error → `criticalErrorMessage` is set and shown in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)