### PR TITLE
fix: track in-progress items to surface them in UI and recover on restart (#121)

### DIFF
--- a/internal/database/migrations/005_add_in_progress_items.sql
+++ b/internal/database/migrations/005_add_in_progress_items.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- Track items currently being processed so they can be recovered if the app crashes
+
+create table if not exists in_progress_items (
+  id text primary key,
+  path text not null,
+  size integer not null,
+  priority integer not null default 0,
+  created_at text not null,
+  started_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ')),
+  job_data blob not null
+);
+
+create index if not exists in_progress_items_path_idx on in_progress_items (path);
+
+-- +goose Down
+drop index if exists in_progress_items_path_idx;
+drop table if exists in_progress_items;


### PR DESCRIPTION
## Summary

Fixes #121 — queue items disappearing from the UI when the app crashes or restarts mid-upload.

**Root cause**: `ReceiveFile()` deleted items from the goqite table immediately on dequeue. If the app crashed before `CompleteFile`/`MarkAsError` was called, the item was gone from goqite but not in `completed_items` or `errored_items`, making it permanently invisible.

**Changes**:
- Add a new migration (`005_add_in_progress_items.sql`) with an `in_progress_items` table
- `ReceiveFile`: inserts item into `in_progress_items` before deleting from goqite
- `CompleteFile` / `MarkAsError`: removes item from `in_progress_items`
- `recoverInProgressItems`: called at queue startup, re-queues any orphaned rows left in `in_progress_items` from a previous crash so they are processed again
- `GetQueueItems`: union query now includes `in_progress_items` with `status = "running"`
- `GetQueueStats`: `running` count now comes from `in_progress_items` instead of always returning 0
- `IsPathInQueue` / `RemoveFromQueue`: updated to handle `in_progress_items`

## Test plan

- [ ] Add a file to the queue and start upload → item appears as "running" in UI
- [ ] Kill the app mid-upload → restart → item reappears as "pending" and gets re-processed
- [ ] Normal upload completes → item moves to "complete", no longer in "running"
- [ ] Upload fails → item moves to "error", no longer in "running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)