### PR TITLE
fix: sort active upload jobs alphabetically by filename

### DIFF
--- a/frontend/src/lib/components/dashboard/ProgressSection.svelte
+++ b/frontend/src/lib/components/dashboard/ProgressSection.svelte
@@ -170,7 +170,7 @@ function cancelUpload(jobID: string) {
 
   {#if $isUploading}
     <!-- Running Jobs with Progress -->
-    {#each $runningJobs as job (job.id)}
+    {#each [...$runningJobs].sort((a, b) => (a.fileName ?? '').localeCompare(b.fileName ?? '')) as job (job.id)}
       <div class="card bg-base-100 shadow-xl p-6 hover:shadow-2xl transition-all duration-200">
         <div class="space-y-6">
           <div class="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- Sorts the running jobs list in `ProgressSection.svelte` by `fileName` before rendering
- Uses a non-mutating sort (`[...$runningJobs].sort(...)`) to avoid side effects on the store

## Test plan

- [ ] Start uploading multiple files simultaneously
- [ ] Verify the jobs appear in the Upload Progress section in alphabetical order by filename

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)