### PR TITLE
feat: add manual scan trigger button to watcher dashboard

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -278,6 +278,7 @@ func (ws *WebServer) setupRoutes() {
 	api.HandleFunc("/filesystem/browse", ws.handleBrowseFilesystem).Methods("GET")
 	api.HandleFunc("/filesystem/import", ws.handleImportFiles).Methods("POST")
 	api.HandleFunc("/watcher/status", ws.handleGetWatcherStatus).Methods("GET")
+	api.HandleFunc("/watcher/scan", ws.handleTriggerScan).Methods("POST")
 
 	// Serve static files (catch-all)
 	ws.router.PathPrefix("/").Handler(ws.getStaticFileHandler())
@@ -354,6 +355,12 @@ func (ws *WebServer) handleGetWatcherStatus(w http.ResponseWriter, r *http.Reque
 	status := ws.app.GetWatcherStatus()
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(status)
+}
+
+func (ws *WebServer) handleTriggerScan(w http.ResponseWriter, r *http.Request) {
+	ws.app.TriggerScan()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (ws *WebServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -295,6 +295,22 @@ export class UnifiedClient {
 		throw new Error("No client available");
 	}
 
+	async triggerScan(): Promise<void> {
+		await this.initialize();
+
+		if (this._environment === "wails") {
+			const client = await getWailsClient();
+			return client.App.TriggerScan();
+		}
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.triggerScan();
+		}
+
+		throw new Error("No client available");
+	}
+
 	async getRunningJobDetails(): Promise<processor.RunningJobDetails[]> {
 		await this.initialize();
 

--- a/frontend/src/lib/api/web-client.ts
+++ b/frontend/src/lib/api/web-client.ts
@@ -187,6 +187,10 @@ export class WebClient {
 		return this.get<watcher.WatcherStatusInfo>("/watcher/status");
 	}
 
+	async triggerScan(): Promise<void> {
+		return this.post<void>("/watcher/scan");
+	}
+
 	async pauseProcessing(): Promise<void> {
 		return this.post<void>("/processor/pause");
 	}

--- a/frontend/src/lib/locales/en/dashboard.json
+++ b/frontend/src/lib/locales/en/dashboard.json
@@ -190,7 +190,10 @@
 			"next_run_soon": "Soon",
 			"next_run_minutes": "in {count} {count, plural, =1 {minute} other {minutes}}",
 			"next_run_hours": "in {count} {count, plural, =1 {hour} other {hours}}",
-			"next_run_days": "in {count} {count, plural, =1 {day} other {days}}"
+			"next_run_days": "in {count} {count, plural, =1 {day} other {days}}",
+			"scan_now": "Scan Now",
+			"scan_triggered": "Scan Triggered",
+			"scan_triggered_description": "Directory scan has been started"
 		}
 	}
 }

--- a/frontend/src/lib/locales/es/dashboard.json
+++ b/frontend/src/lib/locales/es/dashboard.json
@@ -192,7 +192,10 @@
 			"next_run_soon": "Pronto",
 			"next_run_minutes": "en {count} {count, plural, =1 {minuto} other {minutos}}",
 			"next_run_hours": "en {count} {count, plural, =1 {hora} other {horas}}",
-			"next_run_days": "en {count} {count, plural, =1 {día} other {días}}"
+			"next_run_days": "en {count} {count, plural, =1 {día} other {días}}",
+			"scan_now": "Escanear ahora",
+			"scan_triggered": "Escaneo iniciado",
+			"scan_triggered_description": "Se ha iniciado el escaneo del directorio"
 		}
 	}
 }

--- a/frontend/src/lib/locales/fr/dashboard.json
+++ b/frontend/src/lib/locales/fr/dashboard.json
@@ -193,7 +193,10 @@
 			"next_run_soon": "Bientôt",
 			"next_run_minutes": "dans {count} {count, plural, =1 {minute} other {minutes}}",
 			"next_run_hours": "dans {count} {count, plural, =1 {heure} other {heures}}",
-			"next_run_days": "dans {count} {count, plural, =1 {jour} other {jours}}"
+			"next_run_days": "dans {count} {count, plural, =1 {jour} other {jours}}",
+			"scan_now": "Scanner maintenant",
+			"scan_triggered": "Scan déclenché",
+			"scan_triggered_description": "Le scan du répertoire a été lancé"
 		}
 	}
 }

--- a/frontend/src/lib/locales/tr/dashboard.json
+++ b/frontend/src/lib/locales/tr/dashboard.json
@@ -192,7 +192,10 @@
             "next_run_soon": "Yakında",
             "next_run_minutes": "{count} {count, plural, =1 {dakika} other {dakika}} içinde",
             "next_run_hours": "{count} {count, plural, =1 {saat} other {saat}} içinde",
-            "next_run_days": "{count} {count, plural, =1 {gün} other {gün}} içinde"
+            "next_run_days": "{count} {count, plural, =1 {gün} other {gün}} içinde",
+            "scan_now": "Şimdi tara",
+            "scan_triggered": "Tarama başlatıldı",
+            "scan_triggered_description": "Dizin taraması başlatıldı"
         }
     }
 }

--- a/frontend/src/lib/wailsjs/go/backend/App.d.ts
+++ b/frontend/src/lib/wailsjs/go/backend/App.d.ts
@@ -126,6 +126,8 @@ export function Startup(arg1:context.Context):Promise<void>;
 
 export function TestProviderConnectivity(arg1:backend.ServerData):Promise<backend.ValidationResult>;
 
+export function TriggerScan():Promise<void>;
+
 export function UploadFiles():Promise<void>;
 
 export function UploadFolder(arg1:string):Promise<void>;

--- a/frontend/src/lib/wailsjs/go/backend/App.js
+++ b/frontend/src/lib/wailsjs/go/backend/App.js
@@ -242,6 +242,10 @@ export function TestProviderConnectivity(arg1) {
   return window['go']['backend']['App']['TestProviderConnectivity'](arg1);
 }
 
+export function TriggerScan() {
+  return window['go']['backend']['App']['TriggerScan']();
+}
+
 export function UploadFiles() {
   return window['go']['backend']['App']['UploadFiles']();
 }

--- a/internal/backend/watcher.go
+++ b/internal/backend/watcher.go
@@ -74,6 +74,18 @@ func (a *App) initializeWatcher() error {
 	return nil
 }
 
+// TriggerScan triggers an immediate directory scan outside the normal polling interval
+func (a *App) TriggerScan() {
+	defer a.recoverPanic("TriggerScan")
+
+	if a.watcher == nil {
+		slog.Warn("TriggerScan called but watcher is not initialized")
+		return
+	}
+
+	a.watcher.TriggerScan(a.watchCtx)
+}
+
 // GetWatcherStatus returns the current status of the watcher
 func (a *App) GetWatcherStatus() watcher.WatcherStatusInfo {
 	defer a.recoverPanic("GetWatcherStatus")


### PR DESCRIPTION
## Summary

- **Backend (desktop)**: `TriggerScan()` Wails binding added to `internal/backend/watcher.go` — delegates to the watcher's existing `TriggerScan(ctx)` goroutine
- **Backend (web)**: `POST /api/watcher/scan` endpoint added to `cmd/web/main.go`
- **Wails bindings**: `TriggerScan()` manually added to `App.js` and `App.d.ts`
- **API clients**: `triggerScan()` added to `client.ts` (unified) and `web-client.ts`
- **UI**: "Scan Now" button with spinning `RefreshCw` icon added to the `WatcherStatus` dashboard card; disabled when watcher is not initialized
- **i18n**: `scan_now`, `scan_triggered`, `scan_triggered_description` keys added to all 4 locales (en/es/fr/tr)

## Test plan

- [ ] Enable the watcher in settings and set a watch directory
- [ ] Click "Scan Now" in the File Watcher card on the dashboard
- [ ] Verify a toast notification confirms the scan was triggered
- [ ] Confirm files placed in the watch directory are picked up immediately
- [ ] Test in both desktop (Wails) and web/Docker modes
- [ ] Verify the button is disabled when the watcher is not initialized

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)