### PR TITLE
feat: unified settings save button (sticky bar)

### DIFF
--- a/frontend/src/lib/components/settings/FileNamingSection.svelte
+++ b/frontend/src/lib/components/settings/FileNamingSection.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-import apiClient from "$lib/api/client";
 import { t } from "$lib/i18n";
-import { toastStore } from "$lib/stores/toast";
 import type { config as configType } from "$lib/wailsjs/go/models";
-import { FileText, Save } from "lucide-svelte";
+import { FileText } from "lucide-svelte";
 
 interface Props {
 	config: configType.ConfigData;
@@ -13,36 +11,12 @@ let { config = $bindable() }: Props = $props();
 
 // Reactive local state
 let maintainOriginalExtension = $state(config.maintain_original_extension ?? true);
-let saving = $state(false);
-
-// Derived state
-let canSave = $derived(!saving);
 
 // Sync local state back to config
 $effect(() => {
 	config.maintain_original_extension = maintainOriginalExtension;
 });
 
-async function saveFileNamingSettings() {
-	if (!canSave) return;
-	
-	try {
-		saving = true;
-
-		// Get current config to avoid conflicts
-		const currentConfig = await apiClient.getConfig();
-
-		// Update only file naming settings
-		currentConfig.maintain_original_extension = maintainOriginalExtension;
-
-		await apiClient.saveConfig(currentConfig);
-	} catch (error) {
-		console.error("Failed to save file naming settings:", error);
-		toastStore.error($t("common.messages.error_saving"), String(error));
-	} finally {
-		saving = false;
-	}
-}
 </script>
 
 <div class="card bg-base-100 shadow-xl">
@@ -73,17 +47,5 @@ async function saveFileNamingSettings() {
 			</span>
 		</div>
 
-		<!-- Save Button -->
-		<div class="pt-4 border-t border-base-300">
-			<button
-				type="button"
-				class="btn btn-success"
-				onclick={saveFileNamingSettings}
-				disabled={!canSave}
-			>
-				<Save class="w-4 h-4" />
-				{saving ? $t('common.common.saving') : $t('settings.file_naming.save_button')}
-			</button>
-		</div>
 	</div>
 </div>

--- a/frontend/src/lib/components/settings/GeneralSection.svelte
+++ b/frontend/src/lib/components/settings/GeneralSection.svelte
@@ -6,7 +6,7 @@ import ThemeSwitcher from "$lib/components/ThemeSwitcher.svelte";
 import { t } from "$lib/i18n";
 import { toastStore } from "$lib/stores/toast";
 import type { config as configType } from "$lib/wailsjs/go/models";
-import { Cog, FolderOpen, Save } from "lucide-svelte";
+import { Cog, FolderOpen } from "lucide-svelte";
 
 interface Props {
 	config: configType.ConfigData;
@@ -16,10 +16,6 @@ let { config = $bindable() }: Props = $props();
 
 // Reactive local state
 let outputDir = $state(config.output_dir || "./output");
-let saving = $state(false);
-
-// Derived state
-let canSave = $derived(outputDir.trim() && !saving);
 
 // Sync local state back to config
 $effect(() => {
@@ -47,31 +43,6 @@ async function selectOutputDirectory() {
 	}
 }
 
-async function saveGeneralSettings() {
-	if (!canSave) return;
-	
-	try {
-		saving = true;
-
-		// Validation
-		if (!outputDir.trim()) {
-			throw new Error("Output directory is required");
-		}
-
-		// Get current config to avoid conflicts
-		const currentConfig = await apiClient.getConfig();
-
-		// Update only general settings fields
-		currentConfig.output_dir = outputDir.trim();
-
-		await apiClient.saveConfig(currentConfig);
-	} catch (error) {
-		console.error("Failed to save general settings:", error);
-		toastStore.error($t("common.messages.error_saving"), String(error));
-	} finally {
-		saving = false;
-	}
-}
 </script>
 
 <div class="space-y-6">
@@ -117,19 +88,7 @@ async function saveGeneralSettings() {
 				</div>
 			</div>
 
-			<!-- Save Button -->
-			<div class="card-actions pt-4 border-t border-base-300">
-				<button
-					type="button"
-					class="btn btn-success"
-					onclick={saveGeneralSettings}
-					disabled={!canSave}
-				>
-					<Save class="w-4 h-4" />
-					{saving ? $t('common.common.saving') : $t('settings.general.save_button')}
-				</button>
 			</div>
-		</div>
 	</div>
 
 	<div class="card bg-base-100 shadow-xl">

--- a/frontend/src/lib/components/settings/PostingSection.svelte
+++ b/frontend/src/lib/components/settings/PostingSection.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 // Imports
-import apiClient from "$lib/api/client";
 import DurationInput from "$lib/components/inputs/DurationInput.svelte";
 import ThrottleRateInput from "$lib/components/inputs/ThrottleRateInput.svelte";
 import { t } from "$lib/i18n";
 import { advancedMode } from "$lib/stores/app";
-import { toastStore } from "$lib/stores/toast";
 import { config as configType } from "$lib/wailsjs/go/models";
-import { CloudUpload, Plus, Save, Trash2 } from "lucide-svelte";
+import { CloudUpload, Plus, Trash2 } from "lucide-svelte";
   import SizeInput from "$lib/components/inputs/SizeInput.svelte";
 
 // Types
@@ -18,8 +16,6 @@ interface ComponentProps {
 // Props
 let { config = $bindable() }: ComponentProps = $props();
 
-// State
-let saving = $state(false);
 // Reactive local state for form inputs (following best practices)
 let maxRetries = $state(config.posting.max_retries || 3);
 let retryDelay = $state(config.posting.retry_delay || "5s");
@@ -162,31 +158,6 @@ function updateThrottleRate() {
 	// Actual sync happens in $effect above
 }
 
-async function savePostingSettings() {
-	try {
-		saving = true;
-
-		// Get current config to avoid conflicts
-		const currentConfig = await apiClient.getConfig();
-		// Update posting section with type conversion
-		currentConfig.posting = {
-			...config.posting,
-			max_retries: Number.parseInt(String(config.posting.max_retries)) || 3,
-			article_size_in_bytes:
-				Number.parseInt(String(config.posting.article_size_in_bytes)) || 750000,
-			retry_delay: config.posting.retry_delay || "5s",
-			throttle_rate: config.posting.throttle_rate || 0,
-			convertValues: config.posting.convertValues,
-		};
-
-		await apiClient.saveConfig(currentConfig);
-	} catch (error) {
-		console.error("Failed to save posting settings:", error);
-		toastStore.error($t("common.messages.error_saving"), String(error));
-	} finally {
-		saving = false;
-	}
-}
 </script>
 
 <!-- Main Container -->
@@ -536,17 +507,5 @@ async function savePostingSettings() {
       </div>
     </div>
 
-    <!-- Save Button -->
-    <div class="pt-4 border-t border-base-300">
-      <button
-        type="button"
-        class="btn btn-success flex items-center gap-2"
-        onclick={savePostingSettings}
-        disabled={saving}
-      >
-        <Save class="w-4 h-4" />
-        {saving ? $t('common.common.saving') : $t('settings.posting.save_button')}
-      </button>
-    </div>
   </div>
 </div>

--- a/frontend/src/lib/components/settings/WatcherSection.svelte
+++ b/frontend/src/lib/components/settings/WatcherSection.svelte
@@ -12,7 +12,6 @@ import {
 	Eye,
 	Folder,
 	FolderOpen,
-	Save,
 	Trash2,
 } from "lucide-svelte";
 
@@ -28,8 +27,6 @@ $effect(() => {
 		config.watchers = [createDefaultWatcher()];
 	}
 });
-
-let saving = $state(false);
 
 // Track expanded state per watcher card
 let expanded = $state<boolean[]>([]);
@@ -147,26 +144,6 @@ function getWatcherDisplayName(w: configType.WatcherConfig, index: number): stri
 	return $t("settings.watcher.watcher_number", { values: { n: index + 1 } });
 }
 
-async function saveWatcherSettings() {
-	try {
-		saving = true;
-
-		const currentConfig = await apiClient.getConfig();
-		currentConfig.watchers = config.watchers;
-
-		await apiClient.saveConfig(currentConfig);
-
-		toastStore.success(
-			$t("settings.watcher.saved_success"),
-			$t("settings.watcher.saved_success_description")
-		);
-	} catch (error) {
-		console.error("Failed to save watcher settings:", error);
-		toastStore.error($t("common.messages.error_saving"), String(error));
-	} finally {
-		saving = false;
-	}
-}
 </script>
 
 <div class="card bg-base-100 shadow-sm">
@@ -456,17 +433,5 @@ async function saveWatcherSettings() {
       {/each}
     </div>
 
-    <!-- Save Button -->
-    <div class="pt-4 border-t border-base-300">
-      <button
-        type="button"
-        class="btn btn-success"
-        onclick={saveWatcherSettings}
-        disabled={saving}
-      >
-        <Save class="w-4 h-4" />
-        {saving ? $t('common.common.saving') : $t('settings.watcher.save_button')}
-      </button>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Replaces 11 individual per-section save buttons with a single **sticky Save Settings bar** at the bottom of the settings page
- Fixes a bug in `handleSaveConfig` where `parseDuration()` incorrectly converted Go duration strings (e.g. `"5s"`) into nanosecond numbers — Go expects human-readable strings
- Migrates legacy `watcher` (singular) field handling to `watchers` array with proper integer coercion

## Changes

### `+page.svelte`
- Added `let saving = $state(false)` with toggle in `handleSaveConfig`
- Removed all `parseDuration()` calls from duration fields
- Replaced `configToSave.watcher` with `configToSave.watchers.map(...)` handling
- Added sticky bottom bar with "Save Configuration" button, loading spinner, and unsaved-changes indicator

### 11 Section Components
Removed from each: `saving` state, `save*Settings()` function, save button HTML, and unused `apiClient`/`toastStore`/`Save` imports.

**Preserved:**
- `QueueSection`: Clear Queue action button and modal
- `GeneralSection`, `Par2Section`, `WatcherSection`: directory-picker helpers using `apiClient`

## Test plan

- [ ] Open Settings — no individual save buttons visible in any section
- [ ] Edit any field — "unsaved changes" badge appears in header and sticky bar shows the indicator
- [ ] Click **Save Settings** in sticky bar — single success toast, all changes persisted
- [ ] Navigate away with unsaved changes — browser `beforeunload` warning fires
- [ ] QueueSection — "Clear Queue" button still works independently
- [ ] Duration fields (retry delay, check delay, etc.) save correctly without conversion errors
- [ ] `bun run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)