### PR TITLE
feat: allow multiple upload providers with different backbones

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -103,7 +103,7 @@ export class UnifiedClient {
 	}
 
 	private async waitForWailsRuntime(): Promise<void> {
-		const maxAttempts = 50; // Max 5 seconds (50 * 100ms)
+		const maxAttempts = 100; // Max 10 seconds (100 * 100ms) for slow Windows machines
 		let attempts = 0;
 
 		while (attempts < maxAttempts) {
@@ -114,7 +114,8 @@ export class UnifiedClient {
 			attempts++;
 		}
 
-		throw new Error("Wails runtime not available after timeout");
+		console.warn("Wails runtime not available after timeout, proceeding anyway");
+		// Don't throw — let individual API calls fail gracefully
 	}
 
 	// App Status
@@ -156,10 +157,6 @@ export class UnifiedClient {
 
 		if (this._environment === "wails") {
 			const client = await getWailsClient();
-			// #region agent log
-			// Debug instrumentation (no secrets): capture duration-like fields before calling backend.SaveConfig
-			fetch('http://127.0.0.1:7242/ingest/179798b3-2a7a-4cca-82ff-855a1b657b1f',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId:'debug-session',runId:'pre-fix',hypothesisId:'A',location:'frontend/src/lib/api/client.ts:saveConfig',message:'About to call backend.App.SaveConfig (wails)',data:{posting_retry_delay:(config as any)?.posting?.retry_delay,posting_retry_delay_type:typeof (config as any)?.posting?.retry_delay,post_check_delay:(config as any)?.post_check?.delay,post_check_delay_type:typeof (config as any)?.post_check?.delay,connection_pool_hc:(config as any)?.connection_pool?.health_check_interval,connection_pool_hc_type:typeof (config as any)?.connection_pool?.health_check_interval,watcher_check_interval:(config as any)?.watcher?.check_interval,watcher_check_interval_type:typeof (config as any)?.watcher?.check_interval,post_upload_script_timeout:(config as any)?.post_upload_script?.timeout,post_upload_script_timeout_type:typeof (config as any)?.post_upload_script?.timeout,post_upload_script_retry_delay:(config as any)?.post_upload_script?.retry_delay,post_upload_script_retry_delay_type:typeof (config as any)?.post_upload_script?.retry_delay,post_upload_script_max_retries:(config as any)?.post_upload_script?.max_retries,servers_count:Array.isArray((config as any)?.servers)?(config as any).servers.length:0},timestamp:Date.now()})}).catch(()=>{});
-			// #endregion agent log
 			return client.App.SaveConfig(
 				config as unknown as import("$lib/wailsjs/go/models").config.ConfigData,
 			);

--- a/frontend/src/lib/components/NntpServerManager.svelte
+++ b/frontend/src/lib/components/NntpServerManager.svelte
@@ -34,21 +34,10 @@
   // Local reactive state for server properties
   let localServers = $state<configType.ServerConfig[]>([]);
 
-  // Shared host/port/ssl for upload mode
-  let sharedHost = $state("");
-  let sharedPort = $state(119);
-  let sharedSSL = $state(false);
-
   // Initialize local state from props only once
   $effect(() => {
     if (localServers.length === 0 && servers.length > 0) {
       localServers = servers.map((server) => ({ ...server }));
-      // Initialize shared host state when in upload mode
-      if (restrictedRole === "upload") {
-        sharedHost = servers[0].host || "";
-        sharedPort = servers[0].port || 119;
-        sharedSSL = servers[0].ssl ?? false;
-      }
     }
   });
 
@@ -56,17 +45,6 @@
   function updateServers(): void {
     servers = localServers.map((server) => ({ ...server }));
     onupdate?.(servers);
-  }
-
-  // Sync shared host/port/ssl to all upload servers
-  function onSharedHostChange(): void {
-    localServers = localServers.map((s) => ({
-      ...s,
-      host: sharedHost,
-      port: sharedPort,
-      ssl: sharedSSL,
-    }));
-    updateServers();
   }
 
   function addServer(): void {
@@ -80,12 +58,6 @@
 
     if (restrictedRole) {
       newServer.role = restrictedRole;
-    }
-
-    if (restrictedRole === "upload") {
-      newServer.host = sharedHost;
-      newServer.port = sharedPort;
-      newServer.ssl = sharedSSL;
     }
 
     localServers = [...localServers, newServer];
@@ -234,9 +206,9 @@
       return;
     }
 
-    // Basic validation first — for upload mode, use shared host
-    const host = restrictedRole === "upload" ? sharedHost : server.host;
-    const port = restrictedRole === "upload" ? sharedPort : server.port;
+    // Basic validation first
+    const host = server.host;
+    const port = server.port;
 
     if (!host || !port) {
       validationStates = {
@@ -258,7 +230,7 @@
         port,
         username: server.username || "",
         password: server.password || "",
-        ssl: restrictedRole === "upload" ? sharedSSL : (server.ssl || false),
+        ssl: server.ssl || false,
         maxConnections: server.max_connections || 10,
         role: server.role || "upload",
       });
@@ -351,74 +323,6 @@
             {$t("settings.server.bulk_operations.disable_all")}
           </button>
         {/if}
-      </div>
-    </div>
-  {/if}
-
-  <!-- Shared Provider Section (upload mode) -->
-  {#if restrictedRole === "upload"}
-    <div class="p-4 bg-base-200 rounded-lg border border-base-300">
-      <div class="mb-3">
-        <p class="font-medium text-sm text-base-content">
-          {$t("settings.server.upload_pool_provider_label")}
-        </p>
-        <p class="text-xs text-base-content/60 mt-0.5">
-          {$t("settings.server.upload_pool_provider_description")}
-        </p>
-      </div>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div class="md:col-span-2">
-          <label for="shared-host" class="label">
-            <span class="label-text">{$t("settings.server.host")} *</span>
-          </label>
-          <input
-            id="shared-host"
-            class="input input-bordered w-full"
-            bind:value={sharedHost}
-            placeholder="news.example.com"
-            oninput={onSharedHostChange}
-            onchange={onSharedHostChange}
-          />
-        </div>
-        <div>
-          <label for="shared-port" class="label">
-            <span class="label-text">{$t("settings.server.port")} *</span>
-          </label>
-          <input
-            id="shared-port"
-            class="input input-bordered w-full"
-            type="number"
-            bind:value={sharedPort}
-            min="1"
-            max="65535"
-            oninput={onSharedHostChange}
-            onchange={onSharedHostChange}
-          />
-        </div>
-        <div class="flex items-center gap-3 md:col-span-3">
-          <input
-            id="shared-ssl"
-            type="checkbox"
-            class="checkbox"
-            bind:checked={sharedSSL}
-            onchange={onSharedHostChange}
-          />
-          <label for="shared-ssl" class="label-text cursor-pointer">
-            {$t("settings.server.use_ssl_tls")}
-          </label>
-          {#if variant === "settings" && showAdvancedFields}
-            <input
-              id="shared-insecure-ssl"
-              type="checkbox"
-              class="checkbox ml-4"
-              bind:checked={localServers[0]!.insecure_ssl}
-              onchange={() => { localServers = localServers.map(s => ({ ...s, insecure_ssl: localServers[0]!.insecure_ssl })); updateServers(); }}
-            />
-            <label for="shared-insecure-ssl" class="label-text cursor-pointer">
-              {$t("settings.server.allow_insecure_ssl")}
-            </label>
-          {/if}
-        </div>
       </div>
     </div>
   {/if}
@@ -585,73 +489,71 @@
                 </div>
               {/if}
 
-              <!-- Host / Port / SSL — hidden in upload mode (shared at top) -->
-              {#if restrictedRole !== "upload"}
-                <div>
-                  <label for="host-{index}" class="label">
-                    <span class="label-text">
-                      {$t("settings.server.host")} *
-                    </span>
-                  </label>
+              <!-- Host / Port / SSL -->
+              <div>
+                <label for="host-{index}" class="label">
+                  <span class="label-text">
+                    {$t("settings.server.host")} *
+                  </span>
+                </label>
+                <input
+                  id="host-{index}"
+                  class="input input-bordered w-full"
+                  bind:value={localServers[index].host}
+                  placeholder="news.example.com"
+                  required
+                  oninput={() => onServerFieldChange(index)}
+                />
+              </div>
+
+              <div>
+                <label for="port-{index}" class="label">
+                  <span class="label-text">
+                    {$t("settings.server.port")} *
+                  </span>
+                </label>
+                <input
+                  id="port-{index}"
+                  class="input input-bordered w-full"
+                  type="number"
+                  bind:value={localServers[index].port}
+                  min="1"
+                  max="65535"
+                  required
+                  oninput={() => onServerFieldChange(index)}
+                />
+              </div>
+
+              <div class="flex items-center space-x-4 pt-2">
+                <div class="flex items-center">
                   <input
-                    id="host-{index}"
-                    class="input input-bordered w-full"
-                    bind:value={localServers[index].host}
-                    placeholder="news.example.com"
-                    required
-                    oninput={() => onServerFieldChange(index)}
+                    type="checkbox"
+                    class="checkbox mr-2"
+                    bind:checked={localServers[index].ssl}
+                    onchange={() => onServerFieldChange(index)}
                   />
+                  <label for="ssl-{index}" class="label-text cursor-pointer">
+                    {$t("settings.server.use_ssl_tls")}
+                  </label>
                 </div>
 
-                <div>
-                  <label for="port-{index}" class="label">
-                    <span class="label-text">
-                      {$t("settings.server.port")} *
-                    </span>
-                  </label>
-                  <input
-                    id="port-{index}"
-                    class="input input-bordered w-full"
-                    type="number"
-                    bind:value={localServers[index].port}
-                    min="1"
-                    max="65535"
-                    required
-                    oninput={() => onServerFieldChange(index)}
-                  />
-                </div>
-
-                <div class="flex items-center space-x-4 pt-2">
+                {#if variant === "settings" && showAdvancedFields}
                   <div class="flex items-center">
                     <input
                       type="checkbox"
                       class="checkbox mr-2"
-                      bind:checked={localServers[index].ssl}
+                      bind:checked={localServers[index].insecure_ssl}
                       onchange={() => onServerFieldChange(index)}
                     />
-                    <label for="ssl-{index}" class="label-text cursor-pointer">
-                      {$t("settings.server.use_ssl_tls")}
+                    <label
+                      for="insecure-ssl-{index}"
+                      class="label-text cursor-pointer"
+                    >
+                      {$t("settings.server.allow_insecure_ssl")}
                     </label>
                   </div>
-
-                  {#if variant === "settings" && showAdvancedFields}
-                    <div class="flex items-center">
-                      <input
-                        type="checkbox"
-                        class="checkbox mr-2"
-                        bind:checked={localServers[index].insecure_ssl}
-                        onchange={() => onServerFieldChange(index)}
-                      />
-                      <label
-                        for="insecure-ssl-{index}"
-                        class="label-text cursor-pointer"
-                      >
-                        {$t("settings.server.allow_insecure_ssl")}
-                      </label>
-                    </div>
-                  {/if}
-                </div>
-              {/if}
+                {/if}
+              </div>
 
               <div>
                 <label for="username-{index}" class="label">

--- a/frontend/src/lib/components/settings/ServerSection.svelte
+++ b/frontend/src/lib/components/settings/ServerSection.svelte
@@ -6,6 +6,7 @@ import { config as configType } from "$lib/wailsjs/go/models";
 import {
 	Upload,
 	ShieldCheck,
+	AlertTriangle,
 } from "lucide-svelte";
 
 interface Props {
@@ -15,6 +16,18 @@ interface Props {
 let { config = $bindable() }: Props = $props();
 
 let isAdvanced = $derived($advancedMode);
+
+let hasMultipleUploadBackbones = $derived(
+	(() => {
+		const hosts = new Set(
+			config.servers
+				.filter(s => (s.role || "upload") !== "verify" && s.enabled !== false)
+				.map(s => s.host)
+				.filter(h => h)
+		);
+		return hosts.size > 1;
+	})()
+);
 
 // Helper to build a ServerConfig from a plain object
 function toServerConfig(server: any, role: "upload" | "verify"): configType.ServerConfig {
@@ -107,6 +120,13 @@ function handleVerifyUpdate(updatedServers: any[]) {
           </p>
         </div>
       </div>
+
+      {#if hasMultipleUploadBackbones}
+        <div class="alert alert-warning">
+          <AlertTriangle class="w-5 h-5 shrink-0" />
+          <span class="text-sm">{$t("settings.server.multiple_backbones_warning")}</span>
+        </div>
+      {/if}
 
       <NntpServerManager
         servers={uploadManagedServers}

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -384,7 +384,7 @@
 			"validation": {
 				"cannot_disable_last": "Cannot disable the last active provider. At least one provider must remain enabled.",
 				"cannot_set_all_verify": "Cannot set all providers to verify-only. At least one upload server must remain.",
-				"upload_host_conflict": "All upload servers must use the same provider host. Using multiple providers for upload simultaneously is considered spam in Usenet."
+				"upload_host_conflict": ""
 			},
 			"role": "Server Role",
 			"role_upload": "Upload",
@@ -396,11 +396,10 @@
 				"host_required": "Server {number}: Host is required",
 				"port_invalid": "Server {number}: Valid port number is required (1-65535)"
 			},
-			"tip": "<strong>Tip:</strong> Add multiple accounts from the <strong>same provider</strong> to maximize upload bandwidth. Use \"Verify Only\" servers from other providers to confirm articles have propagated across the Usenet backbone.",
+			"tip": "<strong>Tip:</strong> Add multiple accounts to maximize upload bandwidth. Use \"Verify Only\" servers from other providers to confirm articles have propagated across the Usenet backbone. Using multiple different upload providers (backbones) is not recommended.",
+			"multiple_backbones_warning": "Multiple upload providers with different backbones detected. This is not recommended: articles split across backbones may be incomplete or missing for end users. Consider using a single provider for uploading and additional providers for verification only.",
 			"upload_pool_title": "Upload Pool",
-			"upload_pool_description": "Add multiple accounts from the same provider to maximize upload bandwidth",
-			"upload_pool_provider_label": "Provider",
-			"upload_pool_provider_description": "Host and port are shared across all upload accounts",
+			"upload_pool_description": "Add multiple accounts to maximize upload bandwidth",
 			"verify_pool_title": "Verify Pool",
 			"verify_pool_optional": "Optional",
 			"verify_pool_description": "Use servers from other providers to confirm articles have propagated across the Usenet backbone",

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -404,9 +404,9 @@
 			"verify_pool_optional": "Optional",
 			"verify_pool_description": "Use servers from other providers to confirm articles have propagated across the Usenet backbone",
 			"verify_pool_empty_notice": "No verify servers configured — the upload pool will be used for article verification",
-			"add_account": "Add Account",
+			"add_account": "Add Provider",
 			"add_verify_server": "Add Verify Server",
-			"account_number": "Account {number}",
+			"account_number": "Provider {number}",
 			"proxy": {
 				"section_title": "Proxy Settings",
 				"enable_proxy": "Use SOCKS5 Proxy",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -423,7 +423,7 @@
 			"validation": {
 				"cannot_disable_last": "No se puede deshabilitar el último proveedor activo. Al menos un proveedor debe permanecer habilitado.",
 				"cannot_set_all_verify": "No se pueden configurar todos los proveedores como solo verificación. Al menos un servidor de carga debe permanecer.",
-				"upload_host_conflict": "Todos los servidores de carga deben usar el mismo proveedor. Usar múltiples proveedores para carga simultáneamente se considera spam en Usenet."
+				"upload_host_conflict": ""
 			},
 			"role": "Rol del Servidor",
 			"role_upload": "Carga",
@@ -435,11 +435,10 @@
 				"host_required": "Servidor {number}: Se requiere host",
 				"port_invalid": "Servidor {number}: Se requiere un número de puerto válido (1-65535)"
 			},
-			"tip": "<strong>Consejo:</strong> Configure múltiples servidores para mejor redundancia y velocidades de carga. La aplicación distribuirá automáticamente las cargas entre todos los servidores configurados.",
+			"tip": "<strong>Consejo:</strong> Agregue múltiples cuentas para maximizar el ancho de banda de carga. Use servidores en modo \"Solo Verificación\" de otros proveedores para confirmar que los artículos se han propagado. No se recomienda usar múltiples proveedores de carga con diferentes backbones.",
+			"multiple_backbones_warning": "Se detectaron múltiples proveedores de carga con diferentes backbones. Esto no se recomienda: los artículos distribuidos entre diferentes backbones pueden estar incompletos o no disponibles para los usuarios finales. Considere usar un solo proveedor para cargar y proveedores adicionales solo para verificación.",
 			"upload_pool_title": "Pool de Carga",
-			"upload_pool_description": "Agregue múltiples cuentas del mismo proveedor para maximizar el ancho de banda de carga",
-			"upload_pool_provider_label": "Proveedor",
-			"upload_pool_provider_description": "El host y el puerto son compartidos por todas las cuentas de carga",
+			"upload_pool_description": "Agregue múltiples cuentas para maximizar el ancho de banda de carga",
 			"verify_pool_title": "Pool de Verificación",
 			"verify_pool_optional": "Opcional",
 			"verify_pool_description": "Use servidores de otros proveedores para confirmar que los artículos se han propagado por la red Usenet",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -443,9 +443,9 @@
 			"verify_pool_optional": "Opcional",
 			"verify_pool_description": "Use servidores de otros proveedores para confirmar que los artículos se han propagado por la red Usenet",
 			"verify_pool_empty_notice": "Sin servidores de verificación configurados — el pool de carga se usará para verificar artículos",
-			"add_account": "Agregar Cuenta",
+			"add_account": "Agregar Proveedor",
 			"add_verify_server": "Agregar Servidor de Verificación",
-			"account_number": "Cuenta {number}",
+			"account_number": "Proveedor {number}",
 			"proxy": {
 				"section_title": "Configuración de Proxy",
 				"enable_proxy": "Usar Proxy SOCKS5",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -421,7 +421,7 @@
 			"validation": {
 				"cannot_disable_last": "Impossible de désactiver le dernier fournisseur actif. Au moins un fournisseur doit rester activé.",
 				"cannot_set_all_verify": "Impossible de configurer tous les fournisseurs en vérification uniquement. Au moins un serveur d'envoi doit rester.",
-				"upload_host_conflict": "Tous les serveurs d'envoi doivent utiliser le même fournisseur. Utiliser plusieurs fournisseurs pour l'envoi simultané est considéré comme du spam sur Usenet."
+				"upload_host_conflict": ""
 			},
 			"role": "Rôle du Serveur",
 			"role_upload": "Envoi",
@@ -433,11 +433,10 @@
 				"host_required": "Serveur {number} : L'hôte est requis",
 				"port_invalid": "Serveur {number} : Un numéro de port valide est requis (1-65535)"
 			},
-			"tip": "<strong>Astuce :</strong> Configurez plusieurs serveurs pour une meilleure redondance et des vitesses de téléchargement. L'application distribuera automatiquement les téléchargements entre tous les serveurs configurés.",
+			"tip": "<strong>Astuce :</strong> Ajoutez plusieurs comptes pour maximiser la bande passante d'envoi. Utilisez des serveurs en mode \"Vérification Seule\" d'autres fournisseurs pour confirmer la propagation des articles. L'utilisation de plusieurs fournisseurs d'envoi avec des backbones différents n'est pas recommandée.",
+			"multiple_backbones_warning": "Plusieurs fournisseurs d'envoi avec des backbones différents détectés. Ceci n'est pas recommandé : les articles répartis sur plusieurs backbones peuvent être incomplets ou manquants pour les utilisateurs finaux. Envisagez d'utiliser un seul fournisseur pour l'envoi et des fournisseurs supplémentaires uniquement pour la vérification.",
 			"upload_pool_title": "Pool d'Envoi",
-			"upload_pool_description": "Ajoutez plusieurs comptes du même fournisseur pour maximiser la bande passante d'envoi",
-			"upload_pool_provider_label": "Fournisseur",
-			"upload_pool_provider_description": "L'hôte et le port sont partagés entre tous les comptes d'envoi",
+			"upload_pool_description": "Ajoutez plusieurs comptes pour maximiser la bande passante d'envoi",
 			"verify_pool_title": "Pool de Vérification",
 			"verify_pool_optional": "Optionnel",
 			"verify_pool_description": "Utilisez des serveurs d'autres fournisseurs pour confirmer la propagation des articles sur le réseau Usenet",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -441,9 +441,9 @@
 			"verify_pool_optional": "Optionnel",
 			"verify_pool_description": "Utilisez des serveurs d'autres fournisseurs pour confirmer la propagation des articles sur le réseau Usenet",
 			"verify_pool_empty_notice": "Aucun serveur de vérification configuré — le pool d'envoi sera utilisé pour la vérification des articles",
-			"add_account": "Ajouter un Compte",
+			"add_account": "Ajouter un Fournisseur",
 			"add_verify_server": "Ajouter un Serveur de Vérification",
-			"account_number": "Compte {number}",
+			"account_number": "Fournisseur {number}",
 			"proxy": {
 				"section_title": "Paramètres du Proxy",
 				"enable_proxy": "Utiliser un Proxy SOCKS5",

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -402,9 +402,9 @@
             "verify_pool_optional": "İsteğe Bağlı",
             "verify_pool_description": "Makalelerin Usenet ağına yayıldığını doğrulamak için diğer sağlayıcıların sunucularını kullanın",
             "verify_pool_empty_notice": "Doğrulama sunucusu yapılandırılmadı — makale doğrulaması için yükleme havuzu kullanılacak",
-            "add_account": "Hesap Ekle",
+            "add_account": "Sağlayıcı Ekle",
             "add_verify_server": "Doğrulama Sunucusu Ekle",
-            "account_number": "Hesap {number}",
+            "account_number": "Sağlayıcı {number}",
             "proxy": {
                 "section_title": "Proxy Ayarları",
                 "enable_proxy": "SOCKS5 Proxy Kullan",

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -382,7 +382,7 @@
             "validation": {
                 "cannot_disable_last": "Son aktif sağlayıcı devre dışı bırakılamaz. En az bir sağlayıcı etkin kalmalıdır.",
                 "cannot_set_all_verify": "Tüm sağlayıcılar yalnızca doğrulama olarak ayarlanamaz. En az bir yükleme sunucusu kalmalıdır.",
-                "upload_host_conflict": "Tüm yükleme sunucuları aynı sağlayıcıyı kullanmalıdır. Eş zamanlı yükleme için birden fazla sağlayıcı kullanmak Usenet'te spam olarak kabul edilir."
+                "upload_host_conflict": ""
             },
             "role": "Sunucu Rolü",
             "role_upload": "Yükleme",
@@ -394,11 +394,10 @@
                 "host_required": "Sunucu {number}: Ana Bilgisayar gerekli",
                 "port_invalid": "Sunucu {number}: Geçerli port numarası gerekli (1-65535)"
             },
-            "tip": "<strong>İpucu:</strong> Daha iyi yedeklilik ve yükleme hızları için birden fazla sunucu yapılandırın. Uygulama, yüklemeleri yapılandırılmış tüm sunuculara otomatik olarak dağıtacaktır.",
+            "tip": "<strong>İpucu:</strong> Yükleme bant genişliğini artırmak için birden fazla hesap ekleyin. Makalelerin yayıldığını doğrulamak için diğer sağlayıcıların \"Yalnızca Doğrulama\" sunucularını kullanın. Farklı backbone'lara sahip birden fazla yükleme sağlayıcısı kullanmak önerilmez.",
+            "multiple_backbones_warning": "Farklı backbone'lara sahip birden fazla yükleme sağlayıcısı tespit edildi. Bu önerilmez: farklı backbone'lara bölünmüş makaleler son kullanıcılar için eksik veya kayıp olabilir. Yükleme için tek bir sağlayıcı ve ek sağlayıcıları yalnızca doğrulama için kullanmayı düşünün.",
             "upload_pool_title": "Yükleme Havuzu",
-            "upload_pool_description": "Yükleme bant genişliğini artırmak için aynı sağlayıcıdan birden fazla hesap ekleyin",
-            "upload_pool_provider_label": "Sağlayıcı",
-            "upload_pool_provider_description": "Ana bilgisayar ve port tüm yükleme hesapları arasında paylaşılır",
+            "upload_pool_description": "Yükleme bant genişliğini artırmak için birden fazla hesap ekleyin",
             "verify_pool_title": "Doğrulama Havuzu",
             "verify_pool_optional": "İsteğe Bağlı",
             "verify_pool_description": "Makalelerin Usenet ağına yayıldığını doğrulamak için diğer sağlayıcıların sunucularını kullanın",

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,7 +7,7 @@ import ToastContainer from "$lib/components/ToastContainer.svelte";
 import { t } from "$lib/i18n";
 import { appStatus } from "$lib/stores/app";
 import { toastStore } from "$lib/stores/toast";
-import { ChartPie, FileText, Settings, Activity, Globe } from "lucide-svelte";
+import { AlertCircle, ChartPie, FileText, Settings, Activity, Globe } from "lucide-svelte";
 import { availableLocales, locale, setStoredLocale } from "$lib/i18n";
 import { onMount, onDestroy } from "svelte";
 import type { Snippet } from "svelte";
@@ -25,70 +25,75 @@ let connectionStatus: "connected" | "reconnecting" | "disconnected" = $state("co
 let connectionCheckInterval: ReturnType<typeof setInterval> | undefined;
 
 onMount(async () => {
-	// Initialize theme from localStorage or system preference
-	const savedTheme = localStorage.getItem("theme");
-	const systemPrefersDark = window.matchMedia(
-		"(prefers-color-scheme: dark)",
-	).matches;
-	const defaultTheme = savedTheme || (systemPrefersDark ? "dark" : "light");
-	document.documentElement.setAttribute("data-theme", defaultTheme);
+	try {
+		// Initialize theme from localStorage or system preference
+		const savedTheme = localStorage.getItem("theme");
+		const systemPrefersDark = window.matchMedia(
+			"(prefers-color-scheme: dark)",
+		).matches;
+		const defaultTheme = savedTheme || (systemPrefersDark ? "dark" : "light");
+		document.documentElement.setAttribute("data-theme", defaultTheme);
 
-	// Initialize API client (detects environment and sets up appropriate client)
-	await apiClient.initialize();
+		// Initialize API client (detects environment and sets up appropriate client)
+		await apiClient.initialize();
 
-	// Listen for config updates
-	await apiClient.on("config-updated", async () => {
-		await loadAppStatus();
-	});
-
-	// Listen for menu navigation events (desktop only)
-	if (apiClient.environment === "wails") {
-		await apiClient.on("navigate-to-settings", () => {
-			goto("/settings");
+		// Listen for config updates
+		await apiClient.on("config-updated", async () => {
+			await loadAppStatus();
 		});
 
-		await apiClient.on("navigate-to-dashboard", () => {
-			goto("/");
-		});
+		// Listen for menu navigation events (desktop only)
+		if (apiClient.environment === "wails") {
+			await apiClient.on("navigate-to-settings", () => {
+				goto("/settings");
+			});
 
-		// Listen for edit menu events (desktop only)
-		await apiClient.on("menu-cut", () => {
-			document.execCommand("cut");
-		});
+			await apiClient.on("navigate-to-dashboard", () => {
+				goto("/");
+			});
 
-		await apiClient.on("menu-copy", () => {
-			document.execCommand("copy");
-		});
+			// Listen for edit menu events (desktop only)
+			await apiClient.on("menu-cut", () => {
+				document.execCommand("cut");
+			});
 
-		await apiClient.on("menu-paste", () => {
-			document.execCommand("paste");
-		});
+			await apiClient.on("menu-copy", () => {
+				document.execCommand("copy");
+			});
 
-		await apiClient.on("menu-undo", () => {
-			document.execCommand("undo");
-		});
+			await apiClient.on("menu-paste", () => {
+				document.execCommand("paste");
+			});
 
-		await apiClient.on("menu-redo", () => {
-			document.execCommand("redo");
-		});
+			await apiClient.on("menu-undo", () => {
+				document.execCommand("undo");
+			});
 
-		await apiClient.on("menu-select-all", () => {
-			document.execCommand("selectAll");
-		});
-	}
+			await apiClient.on("menu-redo", () => {
+				document.execCommand("redo");
+			});
 
-	// Load initial app status
-	await loadAppStatus();
-
-	// Periodic connection health check
-	connectionCheckInterval = setInterval(async () => {
-		try {
-			await apiClient.getAppStatus();
-			if (connectionStatus !== "connected") connectionStatus = "connected";
-		} catch {
-			connectionStatus = connectionStatus === "connected" ? "reconnecting" : "disconnected";
+			await apiClient.on("menu-select-all", () => {
+				document.execCommand("selectAll");
+			});
 		}
-	}, 10000);
+
+		// Load initial app status
+		await loadAppStatus();
+
+		// Periodic connection health check
+		connectionCheckInterval = setInterval(async () => {
+			try {
+				await apiClient.getAppStatus();
+				if (connectionStatus !== "connected") connectionStatus = "connected";
+			} catch {
+				connectionStatus = connectionStatus === "connected" ? "reconnecting" : "disconnected";
+			}
+		}, 10000);
+	} catch (error) {
+		console.error("Failed to initialize app:", error);
+		toastStore.error($t("common.common.error"), (error as Error).message);
+	}
 });
 
 async function loadAppStatus() {
@@ -272,6 +277,20 @@ function handler(error: unknown, _reset: () => void) {
 			<!-- Setup page takes full screen -->
 			{@render children()}
 		{/if}
+	{#snippet failed(error)}
+		<div class="flex flex-col items-center justify-center min-h-screen text-center space-y-6">
+			<div class="p-6 bg-error/20 rounded-full">
+				<AlertCircle class="w-16 h-16 text-error" />
+			</div>
+			<div class="space-y-2">
+				<h1 class="text-2xl font-bold">{$t('common.common.error')}</h1>
+				<p class="text-base-content/70">{(error as Error).message}</p>
+			</div>
+			<button class="btn btn-primary" onclick={() => window.location.reload()}>
+				Reload
+			</button>
+		</div>
+	{/snippet}
 	</svelte:boundary>
 
 	<!-- Toast notifications -->

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -592,15 +592,6 @@ func (c *ConfigData) validate() error {
 	if len(uploadServers) == 0 {
 		return fmt.Errorf("at least one upload server is required")
 	}
-	uploadHost := uploadServers[0].Host
-	for i, s := range uploadServers[1:] {
-		if s.Host != uploadHost {
-			return fmt.Errorf("upload server %d uses host %q but server 1 uses %q: "+
-				"all upload servers must use the same provider host "+
-				"(add multiple accounts on the same provider, not different providers)", i+2, s.Host, uploadHost)
-		}
-	}
-
 	if len(c.Posting.Groups) == 0 {
 		return fmt.Errorf("posting groups are required")
 	}


### PR DESCRIPTION
## Summary

- Removes the backend validation that required all upload servers to share the same hostname, enabling users to upload through multiple Usenet providers/backbones simultaneously
- Removes the shared host/port/SSL UI block from the upload pool — each server card now shows its own host fields
- Adds a `alert-warning` in the upload pool settings when multiple different hosts are detected, advising users this is not recommended (articles split across backbones may be incomplete for end users)
- Updates tip text and `upload_pool_description` in all 4 locales (en/es/fr/tr) to remove the "same provider" constraint language
- Adds `multiple_backbones_warning` i18n key in all 4 locales
- Also extends Wails runtime wait timeout to 10s and makes it non-fatal for slow Windows machines

## Test plan

- [ ] Go build passes (`go build ./...`)
- [ ] In Settings > Server > Upload Pool: each server card shows its own host/port/SSL fields
- [ ] Can add two upload servers with different hostnames — no backend validation error on save
- [ ] Warning banner appears when two upload servers have different hostnames
- [ ] No warning when all upload servers share the same host
- [ ] Verify translations display correctly in en/es/fr/tr

🤖 Generated with [Claude Code](https://claude.com/claude-code)