### PR TITLE
fix: validate DefaultFrom as a valid RFC 2822 email address

### DIFF
--- a/frontend/src/lib/components/settings/PostingSection.svelte
+++ b/frontend/src/lib/components/settings/PostingSection.svelte
@@ -361,8 +361,8 @@ function updateThrottleRate() {
               id="default-from"
               class="input input-bordered w-full"
               bind:value={defaultFrom}
-              placeholder="poster@example.com"
-              type="email"
+              placeholder="Poster <poster@example.com>"
+              type="text"
             />
             <p class="text-sm text-base-content/70 mt-1">
               {$t('settings.posting.headers.default_from_description')}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/mail"
 	"os"
 	"time"
 
@@ -632,6 +633,13 @@ func (c *ConfigData) validate() error {
 	// Validate queue configuration
 	if c.Queue.MaxConcurrentUploads <= 0 {
 		return fmt.Errorf("queue max concurrent uploads must be positive")
+	}
+
+	// Validate DefaultFrom is a valid RFC 2822 address if set
+	if c.Posting.PostHeaders.DefaultFrom != "" {
+		if _, err := mail.ParseAddress(c.Posting.PostHeaders.DefaultFrom); err != nil {
+			return fmt.Errorf("posting post_headers default_from is not a valid email address: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- **Backend**: Added `net/mail.ParseAddress()` validation in `config.validate()` — a non-empty `PostHeaders.DefaultFrom` must be a valid RFC 2822 address (plain `user@example.com` or display-name `Name <user@example.com>`), otherwise config load is rejected with a descriptive error.
- **Frontend**: Changed the `Default From` input from `type="email"` to `type="text"` and updated the placeholder to `Poster <poster@example.com>` so the display-name format isn't blocked by the browser's built-in email validator.

## Test plan

- [ ] Set `default_from` to an invalid value (e.g. `not-an-email`) — app/API should reject it with `posting post_headers default_from is not a valid email address: ...`
- [ ] Set to a plain email (`poster@example.com`) — accepted
- [ ] Set to display-name format (`Random Poster <poster@example.com>`) — accepted
- [ ] Leave empty — accepted (field is optional)
- [ ] Frontend: confirm the input accepts `Name <email>` without browser blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)