### PR TITLE
fix: validate config, fix provider key format, and bump nntppool to v4.5.3

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -411,6 +411,11 @@ func (ws *WebServer) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := configData.Validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	if err := ws.app.SaveConfig(&configData); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/frontend/src/lib/api/web-client.ts
+++ b/frontend/src/lib/api/web-client.ts
@@ -122,7 +122,8 @@ export class WebClient {
 		});
 
 		if (!response.ok) {
-			throw new Error(`HTTP error! status: ${response.status}`);
+			const errText = await response.text();
+			throw new Error(errText.trim() || `HTTP error! status: ${response.status}`);
 		}
 
 		// Handle empty responses

--- a/frontend/src/lib/components/dashboard/ProviderStatus.svelte
+++ b/frontend/src/lib/components/dashboard/ProviderStatus.svelte
@@ -140,7 +140,7 @@ onDestroy(() => {
 			</div>
 		{:else if poolMetrics?.providers && poolMetrics.providers.length > 0}
 			<div class="space-y-3">
-				{#each poolMetrics.providers as provider (provider.host)}
+				{#each poolMetrics.providers as provider, i (i)}
 					{@const StatusIcon = getProviderStatusIcon(provider)}
 					<div class="border border-base-300 rounded-lg p-4">
 						<div class="flex items-center justify-between mb-3">

--- a/frontend/src/lib/components/settings/ServerSection.svelte
+++ b/frontend/src/lib/components/settings/ServerSection.svelte
@@ -20,8 +20,8 @@ let isAdvanced = $derived($advancedMode);
 let hasMultipleUploadBackbones = $derived(
 	(() => {
 		const hosts = new Set(
-			config.servers
-				.filter(s => (s.role || "upload") !== "verify" && s.enabled !== false)
+			(config.servers ?? [])
+				.filter(s => s != null && (s.role || "upload") !== "verify" && s.enabled !== false)
 				.map(s => s.host)
 				.filter(h => h)
 		);
@@ -50,8 +50,8 @@ function toServerConfig(server: any, role: "upload" | "verify"): configType.Serv
 
 // Derive filtered lists to pass to each NntpServerManager
 let uploadManagedServers = $derived(
-	config.servers
-		.filter(s => (s.role || "upload") !== "verify")
+	(config.servers ?? [])
+		.filter(s => s != null && (s.role || "upload") !== "verify")
 		.map(s => ({
 			enabled: s.enabled ?? true,
 			host: s.host || "",
@@ -70,8 +70,8 @@ let uploadManagedServers = $derived(
 );
 
 let verifyManagedServers = $derived(
-	config.servers
-		.filter(s => s.role === "verify")
+	(config.servers ?? [])
+		.filter(s => s != null && s.role === "verify")
 		.map(s => ({
 			enabled: s.enabled ?? true,
 			host: s.host || "",
@@ -92,13 +92,13 @@ let verifyManagedServers = $derived(
 function handleUploadUpdate(updatedServers: any[]) {
 	config.servers = [
 		...updatedServers.map(s => toServerConfig(s, "upload")),
-		...config.servers.filter(s => s.role === "verify").map(s => toServerConfig(s, "verify")),
+		...(config.servers ?? []).filter(s => s?.role === "verify").map(s => toServerConfig(s, "verify")),
 	];
 }
 
 function handleVerifyUpdate(updatedServers: any[]) {
 	config.servers = [
-		...config.servers.filter(s => (s.role || "upload") !== "verify").map(s => toServerConfig(s, "upload")),
+		...(config.servers ?? []).filter(s => s != null && (s.role || "upload") !== "verify").map(s => toServerConfig(s, "upload")),
 		...updatedServers.map(s => toServerConfig(s, "verify")),
 	];
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/javi11/nntppool/v4 v4.4.2
+	github.com/javi11/nntppool/v4 v4.5.3
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.4
 	github.com/javi11/par2go v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackmordaunt/icns v1.0.0 h1:RYSxplerf/l/DUd09AHtITwckkv/mqjVv4DjYdPmAMQ=
 github.com/jackmordaunt/icns v1.0.0/go.mod h1:7TTQVEuGzVVfOPPlLNHJIkzA6CoV7aH1Dv9dW351oOo=
-github.com/javi11/nntppool/v4 v4.4.2 h1:IWWLf6A+72PjytzSN9vysDTXKSWYJ7sPG2pTX6+gKOk=
-github.com/javi11/nntppool/v4 v4.4.2/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.5.3 h1:40V/KFN0mJw1ZLDILaSmRFcp9Lh42WqlFOypQ0cCC68=
+github.com/javi11/nntppool/v4 v4.5.3/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.4 h1:0aYyORZipp7iX8eNpT/efnzCeVO+9C0sE2HWCGc/JaI=

--- a/internal/backend/app.go
+++ b/internal/backend/app.go
@@ -1105,16 +1105,22 @@ func (a *App) GetNntpPoolMetrics() (NntpPoolMetrics, error) {
 		ProviderErrors:    providerErrors,
 	}
 
-	// Build a map from provider address to inflight config for quick lookup
+	// Build a map from provider address to inflight config for quick lookup.
+	// Key format matches nntppool's internal provider name: "host:port+username" or "host:port".
 	inflightByAddr := make(map[string]int)
 	if a.config != nil {
 		for _, srv := range a.config.Servers {
-			addr := fmt.Sprintf("%s:%d", srv.Host, srv.Port)
+			var key string
+			if srv.Username != "" {
+				key = fmt.Sprintf("%s:%d+%s", srv.Host, srv.Port, srv.Username)
+			} else {
+				key = fmt.Sprintf("%s:%d", srv.Host, srv.Port)
+			}
 			inflight := srv.Inflight
 			if inflight <= 0 {
 				inflight = 10
 			}
-			inflightByAddr[addr] = inflight
+			inflightByAddr[key] = inflight
 		}
 	}
 

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -89,6 +89,11 @@ func (a *App) SaveConfig(configData *config.ConfigData) error {
 
 	slog.Info("Saving config", "path", a.configPath, "configData", configData)
 
+	// Validate structure before anything else (prevents writing bad config to disk)
+	if err := configData.Validate(); err != nil {
+		return err
+	}
+
 	// Ensure version is set to current version when saving
 	configData.Version = config.CurrentConfigVersion
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,11 +177,11 @@ type ConfigData struct {
 	ConnectionPool ConnectionPoolConfig `yaml:"connection_pool" json:"connection_pool"`
 	Posting        PostingConfig        `yaml:"posting" json:"posting"`
 	// Check uploaded article configuration. used to check if an article was successfully uploaded and propagated.
-	PostCheck                 PostCheck              `yaml:"post_check" json:"post_check"`
-	Par2                      Par2Config             `yaml:"par2" json:"par2"`
+	PostCheck PostCheck  `yaml:"post_check" json:"post_check"`
+	Par2      Par2Config `yaml:"par2" json:"par2"`
 	// Watcher is deprecated: use Watchers instead. Retained for backward-compatible YAML parsing.
-	Watcher        WatcherConfig  `yaml:"watcher,omitempty" json:"watcher,omitempty"`
-	Watchers       []WatcherConfig `yaml:"watchers" json:"watchers"`
+	Watcher                   WatcherConfig          `yaml:"watcher,omitempty" json:"watcher,omitempty"`
+	Watchers                  []WatcherConfig        `yaml:"watchers" json:"watchers"`
 	NzbCompression            NzbCompressionConfig   `yaml:"nzb_compression" json:"nzb_compression"`
 	Database                  DatabaseConfig         `yaml:"database" json:"database"`
 	Queue                     QueueConfig            `yaml:"queue" json:"queue"`
@@ -200,16 +200,16 @@ type Par2Config struct {
 
 // ServerConfig represents a Usenet server configuration
 type ServerConfig struct {
-	Host                           string     `yaml:"host" json:"host"`
-	Port                           int        `yaml:"port" json:"port"`
-	Username                       string     `yaml:"username" json:"username"`
-	Password                       string     `yaml:"password" json:"password"`
-	SSL                            bool       `yaml:"ssl" json:"ssl"`
-	MaxConnections                 int        `yaml:"max_connections" json:"max_connections"`
-	MaxConnectionIdleTimeInSeconds int        `yaml:"max_connection_idle_time_in_seconds" json:"max_connection_idle_time_in_seconds"`
-	MaxConnectionTTLInSeconds      int        `yaml:"max_connection_ttl_in_seconds" json:"max_connection_ttl_in_seconds"`
-	InsecureSSL                    bool       `yaml:"insecure_ssl" json:"insecure_ssl"`
-	Enabled                        *bool      `yaml:"enabled" json:"enabled"`
+	Host                           string `yaml:"host" json:"host"`
+	Port                           int    `yaml:"port" json:"port"`
+	Username                       string `yaml:"username" json:"username"`
+	Password                       string `yaml:"password" json:"password"`
+	SSL                            bool   `yaml:"ssl" json:"ssl"`
+	MaxConnections                 int    `yaml:"max_connections" json:"max_connections"`
+	MaxConnectionIdleTimeInSeconds int    `yaml:"max_connection_idle_time_in_seconds" json:"max_connection_idle_time_in_seconds"`
+	MaxConnectionTTLInSeconds      int    `yaml:"max_connection_ttl_in_seconds" json:"max_connection_ttl_in_seconds"`
+	InsecureSSL                    bool   `yaml:"insecure_ssl" json:"insecure_ssl"`
+	Enabled                        *bool  `yaml:"enabled" json:"enabled"`
 	// Role defines how this server is used: "upload" for posting, "verify" for STAT checks only.
 	// All upload-role servers must share the same provider host.
 	Role ServerRole `yaml:"role" json:"role"`
@@ -565,15 +565,15 @@ func Load(path string) (*ConfigData, error) {
 	cfg.migrateWatcherConfig()
 
 	// Validate configuration
-	if err := cfg.validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	return &cfg, nil
 }
 
-// validate validates the configuration
-func (c *ConfigData) validate() error {
+// Validate validates the configuration
+func (c *ConfigData) Validate() error {
 	for i, s := range c.Servers {
 		if s.Host == "" {
 			return fmt.Errorf("server %d: host is required", i)
@@ -586,6 +586,17 @@ func (c *ConfigData) validate() error {
 		if s.MaxConnections <= 0 {
 			return fmt.Errorf("server %d: max_connections must be positive", i)
 		}
+	}
+
+	// Validate that no two servers share the same host+username (would collide in nntppool)
+	type serverKey struct{ host, username string }
+	seen := make(map[serverKey]int)
+	for i, s := range c.Servers {
+		k := serverKey{s.Host, s.Username}
+		if j, exists := seen[k]; exists {
+			return fmt.Errorf("servers %d and %d have the same host (%q) and username (%q); each provider account must be unique", j+1, i+1, s.Host, s.Username)
+		}
+		seen[k] = i
 	}
 
 	// Validate upload servers: at least one required, all must share the same host
@@ -770,7 +781,7 @@ func (c *ConfigData) GetNNTPPool() (*nntppool.Client, error) {
 
 	providers := getProviders(enabledServers)
 
-	client, err := nntppool.NewClient(context.Background(), providers)
+	client, err := nntppool.NewClient(context.Background(), providers, nntppool.WithDispatchStrategy(nntppool.DispatchRoundRobin))
 	if err != nil {
 		return nil, fmt.Errorf("error creating NNTP client: %w", err)
 	}
@@ -802,7 +813,7 @@ func (c *ConfigData) GetVerifyPool() (*nntppool.Client, error) {
 
 	if len(verifyServers) > 0 {
 		providers := getProviders(verifyServers)
-		client, err := nntppool.NewClient(context.Background(), providers)
+		client, err := nntppool.NewClient(context.Background(), providers, nntppool.WithDispatchStrategy(nntppool.DispatchRoundRobin))
 		if err != nil {
 			return nil, fmt.Errorf("error creating verify pool: %w", err)
 		}
@@ -960,9 +971,9 @@ func GetDefaultConfig() ConfigData {
 				IgnorePatterns:     []string{"*.tmp", "*.part", "*.!ut"},
 				MinFileSize:        1048576, // 1MB
 				CheckInterval:      Duration("5m"),
-				DeleteOriginalFile: false,        // Default to keeping original files for safety
-				SingleNzbPerFolder: false,        // Default to false for backward compatibility
-				FollowSymlinks:     false,        // Default to skipping symlinks to avoid double-counting and external files
+				DeleteOriginalFile: false,           // Default to keeping original files for safety
+				SingleNzbPerFolder: false,           // Default to false for backward compatibility
+				FollowSymlinks:     false,           // Default to skipping symlinks to avoid double-counting and external files
 				MinFileAge:         Duration("60s"), // Default to 60s to ensure files are stable before uploading
 			},
 		},

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -106,8 +106,11 @@ func (m *Manager) GetCheckPool() NNTPClient {
 	return m.GetVerifyPool()
 }
 
-// providerKey returns a unique key for a server config (used to match providers across config changes).
+// providerKey returns a unique key for a server config matching nntppool's internal provider name format.
 func providerKey(s config.ServerConfig) string {
+	if s.Username != "" {
+		return fmt.Sprintf("%s:%d+%s", s.Host, s.Port, s.Username)
+	}
 	return fmt.Sprintf("%s:%d", s.Host, s.Port)
 }
 
@@ -145,7 +148,9 @@ func (m *Manager) UpdateConfig(newCfg *config.ConfigData) error {
 	// Diff upload providers
 	oldUploadServers := m.config.GetUploadServers()
 	newUploadServers := newCfg.GetUploadServers()
-	m.diffProviders(m.uploadPool, oldUploadServers, newUploadServers, "upload")
+	if err := m.diffProviders(m.uploadPool, oldUploadServers, newUploadServers, "upload"); err != nil {
+		return fmt.Errorf("upload pool update failed: %w", err)
+	}
 
 	// Diff verify providers
 	oldVerifyServers := m.config.GetVerifyServers()
@@ -158,7 +163,9 @@ func (m *Manager) UpdateConfig(newCfg *config.ConfigData) error {
 	switch {
 	case hasNewVerify && hasOldVerify && m.verifyPool != m.uploadPool:
 		// Both old and new have dedicated verify pools — diff the verify pool
-		m.diffProviders(m.verifyPool, oldVerifyServers, newVerifyServers, "verify")
+		if err := m.diffProviders(m.verifyPool, oldVerifyServers, newVerifyServers, "verify"); err != nil {
+			return fmt.Errorf("verify pool update failed: %w", err)
+		}
 	case hasNewVerify && !hasOldVerify:
 		// New config introduces verify servers — create dedicated verify pool
 		verifyPool, err := newCfg.GetVerifyPool()
@@ -190,7 +197,7 @@ func (m *Manager) UpdateConfig(newCfg *config.ConfigData) error {
 
 // diffProviders computes the diff between old and new server lists and applies
 // AddProvider/RemoveProvider operations on the given pool.
-func (m *Manager) diffProviders(pool NNTPClient, oldServers, newServers []config.ServerConfig, poolName string) {
+func (m *Manager) diffProviders(pool NNTPClient, oldServers, newServers []config.ServerConfig, poolName string) error {
 	oldMap := make(map[string]config.ServerConfig, len(oldServers))
 	for _, s := range oldServers {
 		oldMap[providerKey(s)] = s
@@ -220,13 +227,12 @@ func (m *Manager) diffProviders(pool NNTPClient, oldServers, newServers []config
 		if !exists || serverConfigChanged(oldSrv, newSrv) {
 			provider := config.ServerConfigToProvider(newSrv)
 			if err := pool.AddProvider(provider); err != nil {
-				slog.Error("Failed to add provider to pool",
-					"pool", poolName, "provider", key, "error", err)
-			} else {
-				slog.Info("Added provider to pool", "pool", poolName, "provider", key)
+				return fmt.Errorf("failed to add provider %q to %s pool: %w", key, poolName, err)
 			}
+			slog.Info("Added provider to pool", "pool", poolName, "provider", key)
 		}
 	}
+	return nil
 }
 
 // serverConfigChanged returns true if any relevant fields differ between two server configs.


### PR DESCRIPTION
## Summary

- **Config validation**: Expose `Validate()` publicly and call it in both the Wails backend (`backend/config.go`) and web handler (`cmd/web/main.go`) before saving, so invalid configs are rejected before reaching disk. HTTP error responses now include the validation message body.
- **Provider key fix**: `providerKey()` in `pool/manager.go` and `inflightByAddr` in `app.go` now use `host:port+username` format, matching nntppool's internal provider name — fixing dynamic `AddProvider`/`RemoveProvider` diffs and per-provider metrics attribution.
- **Duplicate account validation**: Added check in `Validate()` to reject two servers sharing the same host+username, preventing silent nntppool collisions.
- **nntppool v4.5.3**: Bumps the library which fixes FIFO-only POST dispatch so round-robin across multiple upload providers works correctly.
- **Round-robin for all pools**: Applied `WithDispatchStrategy(DispatchRoundRobin)` to `GetNNTPPool` and `GetVerifyPool` (was only on `GetUploadPool`).
- **Error propagation**: `diffProviders()` now returns an error and `UpdateConfig()` propagates it.
- **Frontend fixes**: Null-guard `config.servers` in `ServerSection.svelte`; fix `{#each}` key in `ProviderStatus.svelte` to use index instead of host.

## Test plan

- [ ] Configure 2 upload providers with different hosts; verify both appear active in dashboard and receive articles during upload
- [ ] Configure 2 servers with the same host+username; verify save is rejected with a clear error message
- [ ] Reload config with a changed server password; verify `UpdateConfig` correctly removes and re-adds the provider
- [ ] Web mode: save invalid config via API and confirm HTTP 400 with descriptive body
- [ ] Dashboard provider list renders correctly when multiple providers share the same host

🤖 Generated with [Claude Code](https://claude.com/claude-code)