### PR TITLE
fix: prevent false "unsaved changes" badge when switching settings tabs

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -19,7 +19,7 @@ import { advancedMode, appStatus, settingsSaveFunction } from "$lib/stores/app";
 import { toastStore } from "$lib/stores/toast";
 import { backend, config as configType } from "$lib/wailsjs/go/models";
 import { AlertCircle, CheckCircle, RefreshCw, Save, Settings } from "lucide-svelte";
-import { onDestroy, onMount } from "svelte";
+import { onDestroy, onMount, tick } from "svelte";
 
 let configData: configType.ConfigData | null = $state(null);
 let localConfig: configType.ConfigData | null = $state(null);
@@ -65,7 +65,6 @@ async function loadConfig() {
 		) {
 			localConfig.servers = [new configType.ServerConfig()];
 		}
-		savedConfigSnapshot = JSON.stringify(localConfig);
 		isDirty = false;
 	} catch (error) {
 		console.error("Failed to load config:", error);
@@ -74,6 +73,13 @@ async function loadConfig() {
 		localConfig = null;
 	} finally {
 		loading = false;
+	}
+
+	// After loading=false, components render and run initializeDefaults().
+	// tick() waits for that DOM update cycle before capturing the snapshot.
+	if (localConfig) {
+		await tick();
+		savedConfigSnapshot = JSON.stringify(localConfig);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where the \"unsaved changes\" badge appeared on settings tabs even without any user edits
- Root cause: `savedConfigSnapshot` was captured before section components mounted and ran `initializeDefaults()`, creating a mismatch with defaults set by `PostingSection`
- Fix: `await tick()` after `loading = false` lets all components complete initialization before the baseline snapshot is taken

## Test plan

- [ ] Open the settings page
- [ ] Switch between all tabs without modifying anything — "unsaved changes" badge should NOT appear
- [ ] Make an actual change (e.g. edit a field) — badge should appear
- [ ] Save — badge should disappear
- [ ] Reload settings, switch tabs again — badge should not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)