### PR TITLE
fix: correct nested folder NZB grouping and filename for dotted folder names

### DIFF
--- a/internal/nzb/nzb.go
+++ b/internal/nzb/nzb.go
@@ -334,6 +334,10 @@ func (g *Generator) AddFileHash(filename string, hash string) {
 
 // generateFinalNzbPath creates the final NZB path based on the configuration
 func (g *Generator) generateFinalNzbPath(originalFilePath string) string {
+	if strings.HasSuffix(strings.ToLower(originalFilePath), ".nzb") {
+		return originalFilePath
+	}
+
 	dir := filepath.Dir(originalFilePath)
 	basename := filepath.Base(originalFilePath)
 

--- a/internal/nzb/nzb_test.go
+++ b/internal/nzb/nzb_test.go
@@ -291,6 +291,53 @@ func TestGenerate(t *testing.T) {
 		assert.NoError(t, err, "Compressed NZB file should exist")
 	})
 
+	t.Run("folder name with dots does not get truncated at first dot", func(t *testing.T) {
+		segmentSize := uint64(1000)
+		compressionConfig := config.NzbCompressionConfig{
+			Enabled: false,
+			Type:    config.CompressionTypeNone,
+			Level:   0,
+		}
+
+		// maintainOriginalExtension=false triggers the old buggy path that split on dots
+		generator := NewGenerator(segmentSize, compressionConfig, false).(*Generator)
+
+		testArticle := &article.Article{
+			MessageID:       "test-message-id-1",
+			OriginalName:    "file.rar",
+			OriginalSubject: "Test Subject",
+			From:            "test@example.com",
+			Groups:          []string{"alt.test"},
+			PartNumber:      1,
+			TotalParts:      1,
+			Size:            500,
+			FileNumber:      1,
+			FileName:        "file.rar",
+		}
+		generator.AddArticle(testArticle)
+
+		tempDir, err := os.MkdirTemp("", "nzb-test")
+		require.NoError(t, err)
+		defer func() {
+			_ = os.RemoveAll(tempDir)
+		}()
+
+		outputPath := filepath.Join(tempDir, "Sun.Moments.nzb")
+
+		finalPath, err := generator.Generate(outputPath)
+		require.NoError(t, err, "Generate should succeed")
+
+		assert.Equal(t, outputPath, finalPath, "Returned path must equal the requested output path")
+
+		_, err = os.Stat(outputPath)
+		assert.NoError(t, err, "NZB file should exist at Sun.Moments.nzb")
+
+		// Regression guard: the old bug would create Sun.nzb instead
+		truncatedPath := filepath.Join(tempDir, "Sun.nzb")
+		_, statErr := os.Stat(truncatedPath)
+		assert.True(t, os.IsNotExist(statErr), "Sun.nzb must NOT exist (regression guard)")
+	})
+
 	t.Run("generate with no articles", func(t *testing.T) {
 		segmentSize := uint64(1000)
 		compressionConfig := config.NzbCompressionConfig{

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -227,9 +228,10 @@ func (w *Watcher) scanDirectory(ctx context.Context) error {
 
 // scanDirectoryGroupByFolder scans the directory and groups files by folder for single NZB per folder mode
 func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
-	// Map to collect files by their parent directory
+	// Map to collect files by their top-level subdirectory under the watch folder
 	filesByFolder := make(map[string][]string)
 	sizeByFolder := make(map[string]int64)
+	individualFiles := make(map[string]int64)
 	var mapMutex sync.Mutex
 
 	// Walk the directory tree and collect files by folder
@@ -266,14 +268,23 @@ func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
 			return nil
 		}
 
-		// Get the parent directory
-		folderPath := filepath.Dir(path)
+		// Determine which top-level subdirectory this file belongs to
+		relPath, err := filepath.Rel(w.watchFolder, path)
+		if err != nil {
+			return err
+		}
+		parts := strings.SplitN(filepath.ToSlash(relPath), "/", 2)
 
-		// Add file to the folder's file list
 		mapMutex.Lock()
-		filesByFolder[folderPath] = append(filesByFolder[folderPath], path)
-		sizeByFolder[folderPath] += info.Size()
-
+		if len(parts) == 1 {
+			// File is directly in the watch folder — handle individually
+			individualFiles[path] = info.Size()
+		} else {
+			// File is inside a subdirectory — group under the top-level subdir
+			folderPath := filepath.Join(w.watchFolder, parts[0])
+			filesByFolder[folderPath] = append(filesByFolder[folderPath], path)
+			sizeByFolder[folderPath] += info.Size()
+		}
 		mapMutex.Unlock()
 		return nil
 	})
@@ -355,6 +366,34 @@ func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
 		for _, filePath := range files {
 			slog.DebugContext(ctx, "File in folder", "folder", folderName, "file", filepath.Base(filePath))
 		}
+	}
+
+	// Process files that are directly in the watch folder (not in any subdirectory)
+	for path, size := range individualFiles {
+		// Check if file is currently being processed
+		if w.processor != nil && w.processor.IsPathBeingProcessed(path) {
+			slog.InfoContext(ctx, "File is currently being processed, ignoring", "path", path)
+			continue
+		}
+
+		// Check if file is already in queue
+		inQueue, err := w.queue.IsPathInQueue(path)
+		if err != nil {
+			slog.ErrorContext(ctx, "Error checking if path is in queue", "path", path, "error", err)
+			continue
+		}
+
+		if inQueue {
+			slog.DebugContext(ctx, "File already exists in queue, ignoring", "path", path)
+			continue
+		}
+
+		if err := w.queue.AddFile(ctx, path, size); err != nil {
+			slog.ErrorContext(ctx, "Error adding file to queue", "path", path, "error", err)
+			continue
+		}
+
+		slog.InfoContext(ctx, "Added file to queue", "path", filepath.Base(path), "size", size)
 	}
 
 	return nil

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -887,3 +887,135 @@ func TestSymlinkInGroupByFolder(t *testing.T) {
 		t.Errorf("Expected folder path %s, got %s", expectedPath, mockQueue.addFileCalls[0])
 	}
 }
+
+func TestGroupByFolder_NestedSubdirs(t *testing.T) {
+	watcher, tempDir := createTestWatcher(t)
+
+	content := []byte("test content!!")
+	modTime := time.Now().Add(-10 * time.Second)
+
+	sunMomentsDir := filepath.Join(tempDir, "Sun.Moments")
+	if err := os.MkdirAll(sunMomentsDir, 0755); err != nil {
+		t.Fatalf("Failed to create Sun.Moments dir: %v", err)
+	}
+	proofDir := filepath.Join(sunMomentsDir, "Proof")
+	if err := os.MkdirAll(proofDir, 0755); err != nil {
+		t.Fatalf("Failed to create Proof dir: %v", err)
+	}
+	sampleDir := filepath.Join(sunMomentsDir, "Sample")
+	if err := os.MkdirAll(sampleDir, 0755); err != nil {
+		t.Fatalf("Failed to create Sample dir: %v", err)
+	}
+
+	createTestFile(t, sunMomentsDir, "file1.rar", content, modTime)
+	createTestFile(t, sunMomentsDir, "file2.rar", content, modTime)
+	createTestFile(t, proofDir, "proof.jpg", content, modTime)
+	createTestFile(t, sampleDir, "sample.mkv", content, modTime)
+
+	mockQueue := &mockQueueWithDuplicateCheck{
+		addFileCalls: make([]string, 0),
+	}
+	watcher.queue = mockQueue
+
+	ctx := context.Background()
+	if err := watcher.scanDirectoryGroupByFolder(ctx); err != nil {
+		t.Fatalf("First scan failed: %v", err)
+	}
+	if err := watcher.scanDirectoryGroupByFolder(ctx); err != nil {
+		t.Fatalf("Second scan failed: %v", err)
+	}
+
+	if len(mockQueue.addFileCalls) != 1 {
+		t.Errorf("Expected 1 folder entry, got %d: %v", len(mockQueue.addFileCalls), mockQueue.addFileCalls)
+	}
+
+	expectedPath := "FOLDER:" + filepath.Join(tempDir, "Sun.Moments")
+	if len(mockQueue.addFileCalls) > 0 && mockQueue.addFileCalls[0] != expectedPath {
+		t.Errorf("Expected %s, got %s", expectedPath, mockQueue.addFileCalls[0])
+	}
+}
+
+func TestGroupByFolder_FilesDirectlyInWatchFolder(t *testing.T) {
+	watcher, tempDir := createTestWatcher(t)
+
+	content := []byte("test content!!")
+	modTime := time.Now().Add(-10 * time.Second)
+
+	createTestFile(t, tempDir, "file1.rar", content, modTime)
+	createTestFile(t, tempDir, "file2.rar", content, modTime)
+
+	mockQueue := &mockQueueWithDuplicateCheck{
+		addFileCalls: make([]string, 0),
+	}
+	watcher.queue = mockQueue
+
+	ctx := context.Background()
+	if err := watcher.scanDirectoryGroupByFolder(ctx); err != nil {
+		t.Fatalf("First scan failed: %v", err)
+	}
+	if err := watcher.scanDirectoryGroupByFolder(ctx); err != nil {
+		t.Fatalf("Second scan failed: %v", err)
+	}
+
+	if len(mockQueue.addFileCalls) != 2 {
+		t.Errorf("Expected 2 individual file entries, got %d: %v", len(mockQueue.addFileCalls), mockQueue.addFileCalls)
+	}
+
+	for _, call := range mockQueue.addFileCalls {
+		if len(call) >= 7 && call[:7] == "FOLDER:" {
+			t.Errorf("Expected individual file path, got folder entry: %s", call)
+		}
+	}
+}
+
+func TestGroupByFolder_MixedRootAndSubdir(t *testing.T) {
+	watcher, tempDir := createTestWatcher(t)
+
+	content := []byte("test content!!")
+	modTime := time.Now().Add(-10 * time.Second)
+
+	rootFile := createTestFile(t, tempDir, "standalone.rar", content, modTime)
+
+	releaseDir := filepath.Join(tempDir, "Release")
+	if err := os.MkdirAll(releaseDir, 0755); err != nil {
+		t.Fatalf("Failed to create Release dir: %v", err)
+	}
+	createTestFile(t, releaseDir, "release1.rar", content, modTime)
+	createTestFile(t, releaseDir, "release2.rar", content, modTime)
+
+	mockQueue := &mockQueueWithDuplicateCheck{
+		addFileCalls: make([]string, 0),
+	}
+	watcher.queue = mockQueue
+
+	ctx := context.Background()
+	if err := watcher.scanDirectoryGroupByFolder(ctx); err != nil {
+		t.Fatalf("First scan failed: %v", err)
+	}
+	if err := watcher.scanDirectoryGroupByFolder(ctx); err != nil {
+		t.Fatalf("Second scan failed: %v", err)
+	}
+
+	if len(mockQueue.addFileCalls) != 2 {
+		t.Errorf("Expected 2 entries (1 file + 1 folder), got %d: %v", len(mockQueue.addFileCalls), mockQueue.addFileCalls)
+	}
+
+	expectedFolderEntry := "FOLDER:" + filepath.Join(tempDir, "Release")
+	hasFile := false
+	hasFolder := false
+	for _, call := range mockQueue.addFileCalls {
+		if call == rootFile {
+			hasFile = true
+		}
+		if call == expectedFolderEntry {
+			hasFolder = true
+		}
+	}
+
+	if !hasFile {
+		t.Errorf("Expected individual file entry %s in calls %v", rootFile, mockQueue.addFileCalls)
+	}
+	if !hasFolder {
+		t.Errorf("Expected folder entry %s in calls %v", expectedFolderEntry, mockQueue.addFileCalls)
+	}
+}

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -429,14 +429,19 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 
 	startTime := time.Now()
 
-	// Determine the folder name from the first file's path
-	// This will be used as the NZB filename
-	firstFilePath := files[0].Path
-	folderPath := filepath.Dir(firstFilePath)
-	folderName := filepath.Base(folderPath)
-	if folderName == "." || folderName == "/" {
-		// If files are in root, use a default name
-		folderName = "upload"
+	// Determine the folder name from rootDir (top-level subdir under the watch folder)
+	// This is more robust than deriving from files[0].Path which may be a nested file
+	folderName := filepath.Base(rootDir)
+	if folderName == "." || folderName == "/" || folderName == "" {
+		// Fallback: derive from the first file's relative path
+		relPath, err := filepath.Rel(rootDir, files[0].Path)
+		if err == nil {
+			parts := strings.SplitN(filepath.ToSlash(relPath), "/", 2)
+			folderName = parts[0]
+		}
+		if folderName == "." || folderName == "/" || folderName == "" {
+			folderName = "upload"
+		}
 	}
 
 	slog.InfoContext(ctx, "Posting folder as single NZB", "folder", folderName, "files", len(files))
@@ -517,7 +522,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 		}
 
 		// Generate NZB and return with deferred error if present
-		nzbPath := filepath.Join(outputDir, folderName)
+		nzbPath := filepath.Join(outputDir, folderName+".nzb")
 		finalPath, nzbErr := nzbGen.Generate(nzbPath)
 		if nzbErr != nil {
 			return "", fmt.Errorf("error generating NZB file for folder: %w", nzbErr)
@@ -593,7 +598,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 
 	// Generate single NZB file for the entire folder
 	// Use folder name as the base for NZB filename
-	nzbPath := filepath.Join(outputDir, folderName)
+	nzbPath := filepath.Join(outputDir, folderName+".nzb")
 	finalPath, err := nzbGen.Generate(nzbPath)
 	if err != nil {
 		return "", fmt.Errorf("error generating NZB file for folder: %w", err)


### PR DESCRIPTION
Related #168

## Summary

- **watcher**: Group files by top-level subdirectory under the watch folder instead of immediate parent, so `Sun.Moments/Proof/` and `Sun.Moments/Sample/` correctly collapse into a single `FOLDER:Sun.Moments` queue entry
- **nzb**: Add early-return guard in `generateFinalNzbPath` when the path already ends in `.nzb`, preventing dot-splitting from truncating `Sun.Moments.nzb` → `Sun.nzb`
- **postie**: Derive folder name from `rootDir` (the top-level subdir) instead of `files[0].Path`, and append `.nzb` suffix explicitly at both `Generate()` call sites
- **tests**: 4 new regression tests covering nested subdirs, root-level files, mixed root+subdir scenarios, and dotted folder name NZB generation

## Test plan

- [x] `TestGroupByFolder_NestedSubdirs` — `Sun.Moments/` with `Proof/` and `Sample/` subdirs produces exactly 1 queue entry
- [x] `TestGroupByFolder_FilesDirectlyInWatchFolder` — files at root level enqueued individually (no `FOLDER:` prefix)
- [x] `TestGroupByFolder_MixedRootAndSubdir` — 1 individual file + 1 `FOLDER:Release` entry
- [x] `TestGenerate/folder name with dots does not get truncated at first dot` — `Sun.Moments.nzb` is created, `Sun.nzb` does not exist
- [x] All existing tests continue to pass (`go test ./internal/watcher/... ./internal/nzb/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)