### PR TITLE
feat: add min_file_age_to_delete option for delayed file deletion

### DIFF
--- a/frontend/src/lib/components/settings/WatcherSection.svelte
+++ b/frontend/src/lib/components/settings/WatcherSection.svelte
@@ -53,6 +53,13 @@ const minFileAgePresets = [
   { label: "10m", value: 10, unit: "m" },
 ];
 
+const minFileAgeToDeletePresets = [
+  { label: "0s", value: 0, unit: "s" },
+  { label: "5m", value: 5, unit: "m" },
+  { label: "10m", value: 10, unit: "m" },
+  { label: "30m", value: 30, unit: "m" },
+];
+
 const sizeThresholdPresets = [
   { label: "50MB", value: 50, unit: "MB" },
   { label: "100MB", value: 100, unit: "MB" },
@@ -75,6 +82,7 @@ function createDefaultWatcher(): configType.WatcherConfig {
 	w.watch_directory = "";
 	w.check_interval = "5m";
 	w.min_file_age = "60s";
+	w.min_file_age_to_delete = "0s";
 	w.size_threshold = 104857600;
 	w.min_file_size = 1048576;
 	w.delete_original_file = false;
@@ -292,6 +300,14 @@ function getWatcherDisplayName(w: configType.WatcherConfig, index: number): stri
                   description={$t('settings.watcher.min_file_age_description')}
                   presets={minFileAgePresets}
                   id="min-file-age-{index}"
+                />
+
+                <DurationInput
+                  bind:value={watcher.min_file_age_to_delete}
+                  label={$t('settings.watcher.min_file_age_to_delete')}
+                  description={$t('settings.watcher.min_file_age_to_delete_description')}
+                  presets={minFileAgeToDeletePresets}
+                  id="min-file-age-to-delete-{index}"
                 />
 
                 <SizeInput

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -147,6 +147,8 @@
 			"check_interval_description": "How often to scan for new files",
 			"min_file_age": "Min File Age",
 			"min_file_age_description": "Minimum time since last modification before a file is eligible for upload. Prevents uploading files still being written (e.g. slow copies, torrents).",
+			"min_file_age_to_delete": "Min File Age to Delete",
+			"min_file_age_to_delete_description": "Minimum time to wait after a successful upload before deleting the original file. Use this when a downstream tool (e.g. AltMount) needs time to process the NZB before the source file disappears. Requires 'Delete Original File' to be enabled. Default: 0s (delete immediately).",
 			"size_threshold": "Size Threshold",
 			"size_threshold_description": "Minimum accumulated size before batch processing",
 			"min_file_size": "Min File Size",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -142,6 +142,8 @@
 			"check_interval_description": "Frecuencia para buscar nuevos archivos",
 			"min_file_age": "Antigüedad Mínima del Archivo",
 			"min_file_age_description": "Tiempo mínimo desde la última modificación antes de que un archivo sea elegible para carga. Evita subir archivos que aún se están escribiendo (p. ej. copias lentas, torrents).",
+			"min_file_age_to_delete": "Antigüedad Mínima para Eliminar",
+			"min_file_age_to_delete_description": "Tiempo mínimo de espera tras una subida exitosa antes de eliminar el archivo original. Útil cuando una herramienta dependiente (p. ej. AltMount) necesita tiempo para procesar el NZB antes de que el archivo desaparezca. Requiere 'Eliminar archivo original' activado. Predeterminado: 0s.",
 			"size_threshold": "Umbral de Tamaño",
 			"size_threshold_description": "Tamaño acumulado mínimo antes del procesamiento por lotes",
 			"min_file_size": "Tamaño Mínimo de Archivo",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -142,6 +142,8 @@
 			"check_interval_description": "Fréquence de recherche de nouveaux fichiers",
 			"min_file_age": "Âge Minimum du Fichier",
 			"min_file_age_description": "Durée minimale depuis la dernière modification avant qu'un fichier soit éligible à l'envoi. Évite d'envoyer des fichiers encore en cours d'écriture (ex. copies lentes, torrents).",
+			"min_file_age_to_delete": "Âge Minimum avant Suppression",
+			"min_file_age_to_delete_description": "Durée minimale d'attente après un envoi réussi avant de supprimer le fichier original. Utile lorsqu'un outil en aval (ex. AltMount) a besoin de temps pour traiter le NZB avant que le fichier disparaisse. Nécessite l'option 'Supprimer le fichier original'. Par défaut : 0s.",
 			"size_threshold": "Seuil de Taille",
 			"size_threshold_description": "Taille accumulée minimale avant le traitement par lot",
 			"min_file_size": "Taille Minimale de Fichier",

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -147,6 +147,8 @@
             "check_interval_description": "Yeni dosyaların ne sıklıkla taranacağı",
             "min_file_age": "Minimum Dosya Yaşı",
             "min_file_age_description": "Bir dosyanın yüklenmeye uygun sayılması için son değişiklikten bu yana geçmesi gereken minimum süre. Hâlâ yazılmakta olan dosyaların (ör. yavaş kopyalar, torrentler) yüklenmesini önler.",
+            "min_file_age_to_delete": "Silme için Minimum Dosya Yaşı",
+            "min_file_age_to_delete_description": "Başarılı bir yüklemeden sonra orijinal dosyayı silmeden önce beklenmesi gereken minimum süre. AltMount gibi bir aracın dosya kaybolmadan önce NZB'yi işlemesi için süre tanır. 'Orijinal Dosyayı Sil' seçeneğinin etkin olması gerekir. Varsayılan: 0s.",
             "size_threshold": "Boyut Eşiği",
             "size_threshold_description": "Toplu işlemden önceki minimum birikmiş boyut",
             "min_file_size": "Min Dosya Boyutu",

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -431,6 +431,7 @@ export namespace config {
 	    single_nzb_per_folder: boolean;
 	    follow_symlinks: boolean;
 	    min_file_age: string;
+	    min_file_age_to_delete: string;
 
 	    static createFrom(source: any = {}) {
 	        return new WatcherConfig(source);
@@ -450,6 +451,7 @@ export namespace config {
 	        this.single_nzb_per_folder = source["single_nzb_per_folder"];
 	        this.follow_symlinks = source["follow_symlinks"];
 	        this.min_file_age = source["min_file_age"];
+	        this.min_file_age_to_delete = source["min_file_age_to_delete"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/backend/processor.go
+++ b/internal/backend/processor.go
@@ -82,6 +82,7 @@ func (a *App) initializeProcessor() error {
 		PoolManager:               a.poolManager,
 		OutputFolder:              outputDir,
 		DeleteOriginalFile:        watcherCfg.DeleteOriginalFile,
+		DeleteDelay:               watcherCfg.MinFileAgeToDelete.ToDuration(),
 		MaintainOriginalExtension: a.config.GetMaintainOriginalExtension(),
 		WatchFolder:               watcherCfg.WatchDirectory,
 		FollowSymlinks:            watcherCfg.FollowSymlinks,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,6 +298,11 @@ type WatcherConfig struct {
 	// This prevents uploading files that are still being written to (e.g. slow copies, torrents).
 	// Default: 60s
 	MinFileAge Duration `yaml:"min_file_age" json:"min_file_age"`
+	// MinFileAgeToDelete is the minimum time to wait after a successful upload before
+	// deleting the original file. Useful when a downstream tool (e.g. AltMount) needs
+	// time to import the generated NZB before the source file disappears.
+	// Requires DeleteOriginalFile=true. Default: 0 (delete immediately).
+	MinFileAgeToDelete Duration `yaml:"min_file_age_to_delete" json:"min_file_age_to_delete"`
 }
 
 type ScheduleConfig struct {
@@ -889,6 +894,7 @@ func defaultWatcherConfig() WatcherConfig {
 		SingleNzbPerFolder: false,
 		FollowSymlinks:     false,
 		MinFileAge:         Duration("60s"),
+		MinFileAgeToDelete: Duration("0s"),
 	}
 }
 
@@ -975,6 +981,7 @@ func GetDefaultConfig() ConfigData {
 				SingleNzbPerFolder: false,           // Default to false for backward compatibility
 				FollowSymlinks:     false,           // Default to skipping symlinks to avoid double-counting and external files
 				MinFileAge:         Duration("60s"), // Default to 60s to ensure files are stable before uploading
+				MinFileAgeToDelete: Duration("0s"),  // Default to 0s (delete immediately)
 			},
 		},
 		NzbCompression: NzbCompressionConfig{

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -39,6 +39,7 @@ type Processor struct {
 	jobsMux                   sync.RWMutex
 	jobsWg                    sync.WaitGroup // WaitGroup to track running jobs
 	deleteOriginalFile        bool
+	deleteDelay               time.Duration
 	maintainOriginalExtension bool
 	watchFolder               string // Path to the watch folder for maintaining folder structure
 	followSymlinks            bool   // Control whether to follow symlinks when collecting folder files
@@ -71,6 +72,7 @@ type ProcessorOptions struct {
 	PoolManager               *pool.Manager
 	OutputFolder              string
 	DeleteOriginalFile        bool
+	DeleteDelay               time.Duration // delay before deleting original files
 	MaintainOriginalExtension bool
 	WatchFolder               string
 	FollowSymlinks            bool                                // Control whether to follow symlinks when collecting folder files
@@ -110,6 +112,7 @@ func New(opts ProcessorOptions) *Processor {
 		runningJobs:               make(map[string]*RunningJob),
 		reservedPaths:             make(map[string]time.Time),
 		deleteOriginalFile:        opts.DeleteOriginalFile,
+		deleteDelay:               opts.DeleteDelay,
 		maintainOriginalExtension: opts.MaintainOriginalExtension,
 		watchFolder:               opts.WatchFolder,
 		followSymlinks:            opts.FollowSymlinks,
@@ -452,6 +455,15 @@ func (p *Processor) processFile(ctx context.Context, msg *goqite.Message, job *q
 
 	// Delete the original files if configured
 	if p.deleteOriginalFile {
+		if p.deleteDelay > 0 {
+			slog.InfoContext(ctx, "Waiting before deleting original files", "delay", p.deleteDelay)
+			select {
+			case <-time.After(p.deleteDelay):
+			case <-ctx.Done():
+				slog.WarnContext(ctx, "Context cancelled while waiting to delete files")
+				return actualNzbPath, jobPostie, nil
+			}
+		}
 		for _, fileInfo := range filesToProcess {
 			if err := os.Remove(fileInfo.Path); err != nil {
 				slog.WarnContext(ctx, "Could not delete original file", "path", fileInfo.Path, "error", err)


### PR DESCRIPTION
## Summary

- Adds `min_file_age_to_delete` field to `WatcherConfig` (default `0s` — no behaviour change for existing users)
- After a successful upload, the processor waits the configured duration before deleting the original file; the wait is context-aware so shutdown signals are respected
- Exposes the new option in the Settings UI (`WatcherSection`) with presets (0s / 5m / 10m / 30m) and translations in EN, ES, FR, TR

## Motivation

When AltMount (or similar downstream tools) processes the NZB generated by Postie, the source file can disappear before import completes, breaking torrent clients and dependent systems. Setting `min_file_age_to_delete: 10m` gives the downstream tool a window to act before the file is removed.

## Test plan

- [ ] Set `delete_original_file: true` and `min_file_age_to_delete: 10s`; confirm file still exists ~10 s after upload, then is removed
- [ ] Set delay to `0s`; confirm immediate deletion (existing behaviour unchanged)
- [ ] Trigger shutdown during the delay window; confirm graceful cancellation without hanging
- [ ] Verify the new `DurationInput` appears in the Watcher settings UI with correct presets
- [ ] Verify translations display correctly in all 4 languages
- [ ] `go test ./internal/...` passes

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)