### PR TITLE
fix: prevent signal crash on ProgressSection unmount

### DIFF
--- a/frontend/src/lib/components/dashboard/ProgressSection.svelte
+++ b/frontend/src/lib/components/dashboard/ProgressSection.svelte
@@ -10,6 +10,7 @@ import { onMount, onDestroy } from "svelte";
 // Use the generated types from Wails
 let progressUpdateInterval: NodeJS.Timeout | null = null;
 let isPaused = $state(false);
+let destroyed = false;
 
 // Fetch progress data from API
 async function fetchProgressData() {
@@ -18,6 +19,7 @@ async function fetchProgressData() {
       apiClient.getRunningJobDetails(),
       apiClient.isProcessingPaused()
     ]);
+    if (destroyed) return;
     runningJobs.set(jobDetails);
     isPaused = pausedStatus;
   } catch (error) {
@@ -57,6 +59,7 @@ onMount(() => {
 });
 
 onDestroy(() => {
+  destroyed = true;
   stopPolling();
   document.removeEventListener("visibilitychange", handleVisibilityChange);
 });
@@ -124,15 +127,7 @@ async function cancelJob(jobID: string) {
     await apiClient.cancelJob(jobID);
 
     // Immediately remove the job from running jobs store as a safety measure
-    runningJobs.update((jobs) => {
-      console.log("Force removing cancelled job from running jobs:", jobID);
-      const index = jobs.findIndex((job) => job.id === jobID);
-      if (index !== -1) {
-        jobs.splice(index, 1);
-      }
-      
-      return jobs;
-    });
+    runningJobs.update((jobs) => jobs.filter((job) => job.id !== jobID));
 
     toastStore.success(
       $t("common.messages.job_cancelled"),


### PR DESCRIPTION
## Summary

- Add `destroyed` flag to `ProgressSection.svelte` that is set in `onDestroy`; `fetchProgressData` now returns early if the component has been torn down, preventing writes to destroyed Svelte 5 `$state` signals that caused `Cannot read properties of undefined (reading 'prev')` crashes
- Replace in-place `splice` + same-reference return in `cancelJob` with `filter()`, so the Svelte store receives a new array reference and correctly notifies all subscribers

## Test plan

- [ ] Start several uploads simultaneously and navigate away from the dashboard while they are running — no crash on return
- [ ] Cancel a running job — queue list updates immediately
- [ ] No `Cannot read properties of undefined (reading 'prev')` errors in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)