### PR TITLE
fix: statically link MinGW runtime DLLs in Windows CLI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
             goarch: amd64
             runner: windows-latest
             cc: gcc
-            cgo_ldflags: '-lpthread'
+            cgo_ldflags: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

- Fixes missing `libstdc++-6.dll` and `libwinpthread-1.dll` errors on clean Windows systems when running `postie-cli-windows-amd64.exe`
- Updates `cgo_ldflags` in the Windows matrix entry of `.github/workflows/release.yml` to statically link MinGW runtime libraries into the binary

**Root cause**: `par2go` (introduced in `a045a94`) added a CGo dependency, switching the build to MSYS2 MinGW GCC (`a0f1dd3`). MinGW GCC dynamically links its own runtime by default, producing a binary that requires those DLLs on the target machine.

**Fix**: Changed `cgo_ldflags` from `-lpthread` to `-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic`, which embeds the MinGW runtime directly in the `.exe`.

## Test plan

- [ ] Trigger a build with the new tag and download `postie-cli_vX.X.X_windows_amd64.zip`
- [ ] Copy the `.exe` to a clean Windows machine (no MSYS2/MinGW installed) and run it — should show normal "config not found" error, not DLL missing dialogs
- [ ] Optionally run `dumpbin /dependents postie-cli-windows-amd64.exe` — should only list standard Windows DLLs

Related #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)