### PR TITLE
fix: NZB file named after watch folder instead of subfolder

### DIFF
--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -439,20 +439,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 
 	startTime := time.Now()
 
-	// Determine the folder name from rootDir (top-level subdir under the watch folder)
-	// This is more robust than deriving from files[0].Path which may be a nested file
-	folderName := filepath.Base(rootDir)
-	if folderName == "." || folderName == "/" || folderName == "" {
-		// Fallback: derive from the first file's relative path
-		relPath, err := filepath.Rel(rootDir, files[0].Path)
-		if err == nil {
-			parts := strings.SplitN(filepath.ToSlash(relPath), "/", 2)
-			folderName = parts[0]
-		}
-		if folderName == "." || folderName == "/" || folderName == "" {
-			folderName = "upload"
-		}
-	}
+	folderName := deriveFolderName(rootDir, files)
 
 	slog.InfoContext(ctx, "Posting folder as single NZB", "folder", folderName, "files", len(files))
 
@@ -704,4 +691,29 @@ func (p *Postie) ExecutePostUploadScript(ctx context.Context, nzbPath string, it
 
 	slog.InfoContext(ctx, "Post upload script executed successfully", "command", command, "output", string(output))
 	return nil
+}
+
+// deriveFolderName determines the top-level subfolder name from files relative to rootDir.
+// When rootDir is the watch folder and files live under a subfolder (e.g. SingleNzbPerFolder
+// watcher mode or the "Add Folder" button), this returns that subfolder name rather than the
+// watch folder's own name.
+// Falls back to filepath.Base(rootDir) when files are directly in rootDir or when no files
+// are provided. Falls back further to "upload" when rootDir is "/" or otherwise yields an
+// empty/ambiguous name.
+func deriveFolderName(rootDir string, files []fileinfo.FileInfo) string {
+	if len(files) > 0 {
+		relPath, err := filepath.Rel(rootDir, files[0].Path)
+		if err == nil {
+			parts := strings.SplitN(filepath.ToSlash(relPath), "/", 2)
+			if len(parts) > 1 && parts[0] != "." && parts[0] != "" {
+				return parts[0]
+			}
+		}
+	}
+	// Fallback: use the base name of rootDir itself
+	name := filepath.Base(rootDir)
+	if name == "." || name == "/" || name == "" {
+		return "upload"
+	}
+	return name
 }

--- a/pkg/postie/postie_test.go
+++ b/pkg/postie/postie_test.go
@@ -1,0 +1,78 @@
+package postie
+
+import (
+	"testing"
+
+	"github.com/javi11/postie/pkg/fileinfo"
+)
+
+func TestDeriveFolderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		rootDir  string
+		files    []fileinfo.FileInfo
+		expected string
+	}{
+		{
+			name:    "watch mode single nzb per folder - one level nested",
+			rootDir: "/data/watch",
+			files: []fileinfo.FileInfo{
+				{Path: "/data/watch/MyShow/ep1.mkv"},
+			},
+			expected: "MyShow",
+		},
+		{
+			name:    "watch mode single nzb per folder - deeply nested",
+			rootDir: "/data/watch",
+			files: []fileinfo.FileInfo{
+				{Path: "/data/watch/MyShow/Season1/ep1.mkv"},
+			},
+			expected: "MyShow",
+		},
+		{
+			name:    "add folder button - parent is rootDir",
+			rootDir: "/data/watch",
+			files: []fileinfo.FileInfo{
+				{Path: "/data/watch/MyShow/ep1.mkv"},
+				{Path: "/data/watch/MyShow/ep2.mkv"},
+			},
+			expected: "MyShow",
+		},
+		{
+			// Note: this edge case does NOT occur in normal watcher operation.
+			// When SingleNzbPerFolder=true, files directly in the watch root are
+			// processed individually (one NZB per file) and never reach postFolder.
+			// This fallback only triggers if someone runs "Add Folder" on the watch
+			// folder itself rather than on a subfolder inside it.
+			name:    "files directly in rootDir - fallback to base name",
+			rootDir: "/data/watch",
+			files: []fileinfo.FileInfo{
+				{Path: "/data/watch/ep1.mkv"},
+			},
+			expected: "watch",
+		},
+		{
+			name:    "rootDir is root slash - fallback to upload",
+			rootDir: "/",
+			files: []fileinfo.FileInfo{
+				{Path: "/ep1.mkv"},
+			},
+			expected: "upload",
+		},
+		{
+			name:     "empty files list - fallback to base name",
+			rootDir:  "/data/watch",
+			files:    []fileinfo.FileInfo{},
+			expected: "watch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveFolderName(tt.rootDir, tt.files)
+			if got != tt.expected {
+				t.Errorf("deriveFolderName(%q, files) = %q, want %q", tt.rootDir, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- In watcher mode with `SingleNzbPerFolder` enabled, the locally generated NZB was always named after the watch folder (e.g. `postie-watch.nzb`) instead of the actual subfolder being uploaded (e.g. `big-folder.nzb`)
- Root cause: `postFolder()` derived the NZB name via `filepath.Base(rootDir)`, but `rootDir` is the watch folder (parent), not the subfolder
- Fix: new `deriveFolderName()` helper reads the top-level subfolder name from the first file's relative path, falling back to `filepath.Base(rootDir)` only when files are directly in `rootDir`

## Test plan

- [x] Added 6 table-driven unit tests for `deriveFolderName` in `pkg/postie/postie_test.go`
  - Watch mode + single NZB per folder (one level nested)
  - Watch mode + single NZB per folder (deeply nested `MyShow/Season1/`)
  - Add Folder button with multiple files in subfolder
  - Files directly in rootDir (fallback — not reachable via normal watcher flow)
  - rootDir is `/` (edge case → returns `"upload"`)
  - Empty file list (fallback to rootDir base name)
- [x] `go test ./pkg/postie/... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)