### PR TITLE
ci: add E2E test workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install Bun
+        run: npm install -g bun
+
+      - name: Build frontend
+        run: make build-frontend
+
+      - name: Build web binary
+        run: go build -o ./bin/postie-web ./cmd/web
+
+      - name: Install Chromium
+        run: sudo apt-get install -y chromium-browser
+
+      - name: Run E2E tests
+        run: go test -v -tags e2e -timeout 120s ./tests/e2e/...


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/e2e.yml` to run the Go E2E test suite on every PR and push to `main`
- Builds the frontend and web binary before running tests
- Installs Chromium so chromedp UI tests are not skipped
- Runs all 17 tests (`go test -v -tags e2e -timeout 120s ./tests/e2e/...`)

## Test plan
- [ ] Verify the new "E2E Tests" workflow appears in the Actions tab after merge
- [ ] Confirm all 17 tests pass (9 API + 8 UI via chromedp)
- [ ] Confirm the job fails if the binary fails to build

🤖 Generated with [Claude Code](https://claude.com/claude-code)