### PR TITLE
feat: add {source_path} and {source_dir} placeholders to post-upload script

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -295,7 +295,8 @@ func (p *Processor) processNextItem(ctx context.Context) error {
 		}
 
 		// Execute post upload script if configured (NZB is valid)
-		if scriptErr := jobPostie.ExecutePostUploadScript(ctx, actualNzbPath, completedItemID); scriptErr != nil {
+		sourcePath := strings.TrimPrefix(job.Path, "FOLDER:")
+		if scriptErr := jobPostie.ExecutePostUploadScript(ctx, actualNzbPath, sourcePath, completedItemID); scriptErr != nil {
 			slog.ErrorContext(ctx, "Post upload script execution failed", "error", scriptErr, "nzbPath", actualNzbPath)
 		}
 
@@ -334,7 +335,8 @@ func (p *Processor) processNextItem(ctx context.Context) error {
 	// Execute post upload script if configured
 	// Note: We don't return the error here to avoid failing the completion if the script fails
 	// The script failure will be tracked in the database for retry
-	if scriptErr := jobPostie.ExecutePostUploadScript(ctx, actualNzbPath, string(msg.ID)); scriptErr != nil {
+	sourcePath := strings.TrimPrefix(job.Path, "FOLDER:")
+	if scriptErr := jobPostie.ExecutePostUploadScript(ctx, actualNzbPath, sourcePath, string(msg.ID)); scriptErr != nil {
 		slog.ErrorContext(ctx, "Post upload script execution failed", "error", scriptErr, "nzbPath", actualNzbPath)
 	}
 

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -641,19 +641,21 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 
 // ExecutePostUploadScript executes the post-upload script for a completed item
 // This should be called after the file has been marked as completed in the database
-func (p *Postie) ExecutePostUploadScript(ctx context.Context, nzbPath string, itemID string) error {
+func (p *Postie) ExecutePostUploadScript(ctx context.Context, nzbPath string, sourcePath string, itemID string) error {
 	if !p.postUploadScriptCfg.Enabled || p.postUploadScriptCfg.Command == "" {
 		return nil
 	}
 
-	slog.InfoContext(ctx, "Executing post upload script", "command", p.postUploadScriptCfg.Command, "nzb_path", nzbPath, "item_id", itemID)
+	slog.InfoContext(ctx, "Executing post upload script", "command", p.postUploadScriptCfg.Command, "nzb_path", nzbPath, "source_path", sourcePath, "item_id", itemID)
 
 	// Create timeout context
 	timeoutCtx, cancel := context.WithTimeout(ctx, p.postUploadScriptCfg.Timeout.ToDuration())
 	defer cancel()
 
-	// Replace {nzb_path} placeholder with actual NZB path
+	// Replace placeholders with actual values
 	command := strings.ReplaceAll(p.postUploadScriptCfg.Command, "{nzb_path}", nzbPath)
+	command = strings.ReplaceAll(command, "{source_path}", sourcePath)
+	command = strings.ReplaceAll(command, "{source_dir}", filepath.Dir(sourcePath))
 
 	// Parse command using appropriate shell for the OS
 	var cmd *exec.Cmd


### PR DESCRIPTION
## Summary

- Adds two new placeholders to the post-upload script command configuration:
  - `{source_path}` — full path of the source file (or folder for `FOLDER:` jobs)
  - `{source_dir}` — parent directory of the source file (useful as a `target_path` for import APIs)
- `{nzb_path}` continues to work as before

## Use case

Enables integrations with external APIs that require a target path derived from the original source location. Example:

```
curl -X POST "http://server/import/file?apikey=<key>&target_path={source_dir}" \
  -d '{"file_path": "{nzb_path}"}'
```

For a file at `/mnt/local/Media/Movies/My Movie/My Movie.mkv`:
- `{source_dir}` → `/mnt/local/Media/Movies/My Movie`
- `{source_path}` → `/mnt/local/Media/Movies/My Movie/My Movie.mkv`

## Test plan

- [ ] Configure post-upload script with `{source_dir}` and verify it resolves to the correct directory
- [ ] Test with a regular file job
- [ ] Test with a `FOLDER:` job (prefix is stripped before resolving)
- [ ] Run `go test ./pkg/postie/... ./internal/processor/...`