### PR TITLE
fix: statically link MinGW runtime in Windows CLI builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -139,7 +139,7 @@ jobs:
           go build \
             -trimpath \
             -tags=cli \
-            -ldflags="-s -w -X 'main.Version=${{ steps.version.outputs.version }}'" \
+            -ldflags="-s -w -linkmode external -extldflags '-static' -X 'main.Version=${{ steps.version.outputs.version }}'" \
             -o "postie-cli-windows-amd64.exe" \
             ./cmd/postie/postie.go
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,11 +167,17 @@ jobs:
             EXT=".exe"
           fi
 
+          # Set extra ldflags for static linking on Windows
+          EXTRA_LDFLAGS=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            EXTRA_LDFLAGS="-linkmode external -extldflags '-static'"
+          fi
+
           # Build the binary
           go build \
             -trimpath \
             -tags=cli \
-            -ldflags="-s -w -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
+            -ldflags="-s -w ${EXTRA_LDFLAGS} -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
             -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}" \
             ./cmd/postie/postie.go
 


### PR DESCRIPTION
## Summary
- Add `-linkmode external -extldflags '-static'` to Go linker flags for Windows CLI builds in both `release.yml` and `dev-build.yml`
- Eliminates the need to ship MinGW DLLs (`libgcc_s_seh-1.dll`, `libstdc++-6.dll`, `libwinpthread-1.dll`) alongside the `.exe`
- Aligns CLI builds with the GUI and web builds which already had these flags

Related #198