### PR TITLE
ci: optimize ARM builds with native runners and Zig cross-compiler

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -226,7 +226,7 @@ jobs:
           sbom: false
 
   build-image-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [test, build-frontend]
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           - goos: linux
             goarch: arm64
             runner: ubuntu-latest
-            cc: aarch64-linux-gnu-gcc
+            cc: 'zig cc -target aarch64-linux-musl'
           # macOS builds
           - goos: darwin
             goarch: amd64
@@ -132,14 +132,12 @@ jobs:
           install: mingw-w64-x86_64-gcc
           update: false
 
-      # Install cross-compilation tools
-      - name: Install cross-compilation tools
-        if: matrix.cc != '' && runner.os == 'Linux'
-        run: |
-          sudo apt-get update -qq
-          if [ "${{ matrix.goos }}" = "linux" ] && [ "${{ matrix.goarch }}" = "arm64" ]; then
-            sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          fi
+      # Install Zig for cross-compilation (Linux ARM64)
+      - name: Install Zig
+        if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
 
       # Extract version info
       - name: Extract version info
@@ -513,7 +511,7 @@ jobs:
           sbom: false
 
   build-image-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [test, build-frontend]
     permissions:
       contents: write

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/javi11/nntppool/v4 v4.8.0
+	github.com/javi11/nntppool/v4 v4.9.0
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.4
 	github.com/javi11/par2go v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackmordaunt/icns v1.0.0 h1:RYSxplerf/l/DUd09AHtITwckkv/mqjVv4DjYdPmAMQ=
 github.com/jackmordaunt/icns v1.0.0/go.mod h1:7TTQVEuGzVVfOPPlLNHJIkzA6CoV7aH1Dv9dW351oOo=
-github.com/javi11/nntppool/v4 v4.8.0 h1:IcZPTwXWu1fohTMMQoj6WkW+Gsz8rhuBWFtdFVIIDbk=
-github.com/javi11/nntppool/v4 v4.8.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.9.0 h1:HoAXUP6GhOPqsXIdHp5omqZ8ya8wD9zPbQyTmEmTuzM=
+github.com/javi11/nntppool/v4 v4.9.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.4 h1:0aYyORZipp7iX8eNpT/efnzCeVO+9C0sE2HWCGc/JaI=


### PR DESCRIPTION
## Summary
- Switch Docker ARM64 image builds from `ubuntu-latest` (QEMU emulation) to `ubuntu-24.04-arm` (native ARM runner) in both dev-build and release workflows for ~3-5x faster builds
- Replace `gcc-aarch64-linux-gnu` with Zig cross-compiler (`zig cc -target aarch64-linux-musl`) for CLI ARM64 Linux binary, producing fully static musl-linked binaries without `apt-get` overhead
- Update nntppool dependency from v4.8.0 to v4.9.0

## Test plan
- [ ] Verify dev-build workflow succeeds with ARM64 Docker image on native runner
- [ ] Verify release workflow builds ARM64 Docker image on native runner
- [ ] Verify CLI ARM64 Linux binary compiles correctly with Zig cross-compiler
- [ ] Verify the produced ARM64 binary runs on an ARM64 Linux system