### PR TITLE
ci: verify Windows GUI has no MinGW runtime DLL deps

### DIFF
--- a/.github/actions/verify-windows-gui-dlls/action.yml
+++ b/.github/actions/verify-windows-gui-dlls/action.yml
@@ -1,0 +1,30 @@
+name: Verify Windows GUI DLL dependencies
+description: Fails if the built Windows GUI exe imports MinGW runtime DLLs (libgcc_s_seh-1.dll, libstdc++-6.dll, libwinpthread-1.dll).
+inputs:
+  exe-glob:
+    description: Glob for the built GUI exe
+    required: false
+    default: build/bin/*.exe
+runs:
+  using: composite
+  steps:
+    - name: Check PE imports for forbidden MinGW runtime DLLs
+      shell: msys2 {0}
+      run: |
+        set -euo pipefail
+        exe=$(ls ${{ inputs.exe-glob }} | head -n1)
+        if [ -z "$exe" ]; then
+          echo "::error::No exe found matching glob '${{ inputs.exe-glob }}'"
+          exit 1
+        fi
+        echo "Inspecting: $exe"
+        imports=$(objdump -p "$exe" | grep -i "DLL Name:" || true)
+        echo "--- DLL imports ---"
+        echo "$imports"
+        echo "-------------------"
+        forbidden='libgcc_s_seh-1\.dll|libstdc\+\+-6\.dll|libwinpthread-1\.dll'
+        if echo "$imports" | grep -iE "$forbidden"; then
+          echo "::error::Windows GUI exe depends on MinGW runtime DLL(s); static linking regressed."
+          exit 1
+        fi
+        echo "OK: no MinGW runtime DLL dependencies found."

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -102,6 +102,9 @@ jobs:
           CC: gcc
           CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
 
+      - name: Verify no MinGW runtime DLL dependencies
+        uses: ./.github/actions/verify-windows-gui-dlls
+
       - name: Upload Windows GUI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,6 +416,10 @@ jobs:
           CC: gcc
           CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
 
+      # Verify the built exe doesn't dynamically depend on MinGW runtime DLLs
+      - name: Verify no MinGW runtime DLL dependencies
+        uses: ./.github/actions/verify-windows-gui-dlls
+
       # Upload Windows artifact
       - name: Upload Windows GUI artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add composite action `.github/actions/verify-windows-gui-dlls` that runs `objdump -p` on the built GUI exe and fails if `libgcc_s_seh-1.dll`, `libstdc++-6.dll`, or `libwinpthread-1.dll` appear in the PE import table.
- Call it right after `wails build` in both `dev-build.yml` and `release.yml` `build-gui-windows` jobs.

## Why
Commit b2a3167 statically linked the MinGW runtime so users don't need those three DLLs installed. Nothing in CI currently enforces that — a future flag change or Wails/Go update could silently re-introduce a dynamic dependency and we'd only learn about it from user reports. This check is the regression guard.

The action reuses the MSYS2 MINGW64 setup both jobs already perform, so no extra tooling is added.

## Test plan
- [ ] Confirm `build-gui-windows` in `dev-build.yml` passes on this PR and the new step prints a DLL import list without the three forbidden names.
- [ ] (Optional) On a throwaway branch, drop `-extldflags=-static` / `CGO_LDFLAGS` and confirm the step fails with the expected error before reverting.