### PR TITLE
ci: force external linkmode for static MinGW link in Windows GUI builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -96,11 +96,12 @@ jobs:
         run: npm install -g bun
 
       - name: Build Windows GUI
-        run: wails build -platform windows/amd64 -ldflags="-extldflags=-static"
+        shell: msys2 {0}
+        run: wails build -platform windows/amd64 -ldflags="-linkmode external -extldflags=-static"
         env:
           CGO_ENABLED: 1
           CC: gcc
-          CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
+          CGO_LDFLAGS: '-static-libgcc -static-libstdc++'
 
       - name: Verify no MinGW runtime DLL dependencies
         uses: ./.github/actions/verify-windows-gui-dlls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,11 +410,12 @@ jobs:
 
       # Build Windows GUI using Wails config
       - name: Build Windows GUI
-        run: wails build -platform windows/amd64 -ldflags="-extldflags=-static"
+        shell: msys2 {0}
+        run: wails build -platform windows/amd64 -ldflags="-linkmode external -extldflags=-static"
         env:
           CGO_ENABLED: 1
           CC: gcc
-          CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
+          CGO_LDFLAGS: '-static-libgcc -static-libstdc++'
 
       # Verify the built exe doesn't dynamically depend on MinGW runtime DLLs
       - name: Verify no MinGW runtime DLL dependencies


### PR DESCRIPTION
## Summary

Fixes the `verify-windows-gui-dlls` CI failure where `build/bin/postie.exe` still imported `libstdc++-6.dll` and `libwinpthread-1.dll` despite the recent attempts at static linking (#204, #206).

## Root cause

- The Wails GUI build used `-ldflags=\"-extldflags=-static\"` **without** `-linkmode external`. Go silently ignores `extldflags` unless external linkmode is explicitly selected, so `-static` never reached the linker.
- `CGO_LDFLAGS` ended with `-Wl,-Bdynamic`, which reverted the linker back to dynamic mode for any libs cgo/wails appended after `-lpthread` — including `libstdc++` and `libwinpthread`.
- The step ran under the default PowerShell shell instead of `msys2 {0}`, so `gcc` could resolve to a different toolchain than the MSYS2 mingw64 one set up earlier.

The CLI Windows build did not have this problem because it already passed `-linkmode external -extldflags '-static'` and ran under `bash`.

## Changes

In both `dev-build.yml` and `release.yml` for the `build-gui-windows` job:
- Add `-linkmode external` to wails ldflags so `-extldflags=-static` is honored.
- Drop the `-Wl,-Bstatic -lpthread -Wl,-Bdynamic` dance from `CGO_LDFLAGS` — `gcc -static` covers pthread already.
- Run the build with `shell: msys2 {0}` so the MINGW64 toolchain is unambiguously on PATH.

## Test plan

- [ ] CI `build-gui-windows` succeeds.
- [ ] `verify-windows-gui-dlls` shows no `libgcc_s_seh-1.dll`, `libstdc++-6.dll`, or `libwinpthread-1.dll` in the imports — only `KERNEL32.dll` and `api-ms-win-crt-*` remain.
- [ ] Same verification passes in the release workflow on the next tagged build.