### PR TITLE
ci: inherit Windows PATH in MSYS2 shell for Wails GUI build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -88,6 +88,7 @@ jobs:
           msystem: MINGW64
           install: mingw-w64-x86_64-gcc
           update: false
+          path-type: inherit
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -96,11 +96,12 @@ jobs:
         run: npm install -g bun
 
       - name: Build Windows GUI
-        run: wails build -platform windows/amd64 -ldflags="-extldflags=-static"
+        shell: msys2 {0}
+        run: wails build -platform windows/amd64 -ldflags="-linkmode external -extldflags=-static"
         env:
           CGO_ENABLED: 1
           CC: gcc
-          CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
+          CGO_LDFLAGS: '-static-libgcc -static-libstdc++'
 
       - name: Verify no MinGW runtime DLL dependencies
         uses: ./.github/actions/verify-windows-gui-dlls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,7 @@ jobs:
           msystem: MINGW64
           install: mingw-w64-x86_64-gcc
           update: false
+          path-type: inherit
 
       # Install Wails (version from wails.json)
       - name: Install Wails

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,11 +410,12 @@ jobs:
 
       # Build Windows GUI using Wails config
       - name: Build Windows GUI
-        run: wails build -platform windows/amd64 -ldflags="-extldflags=-static"
+        shell: msys2 {0}
+        run: wails build -platform windows/amd64 -ldflags="-linkmode external -extldflags=-static"
         env:
           CGO_ENABLED: 1
           CC: gcc
-          CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
+          CGO_LDFLAGS: '-static-libgcc -static-libstdc++'
 
       # Verify the built exe doesn't dynamically depend on MinGW runtime DLLs
       - name: Verify no MinGW runtime DLL dependencies


### PR DESCRIPTION
## Summary

Follow-up to #208. The Wails GUI build now runs under `shell: msys2 {0}`, but that shell starts with a clean MSYS2-only PATH by default. Result: `wails` (installed via `go install` into the Windows GOPATH) and `go` itself aren't on PATH, so the step fails with `wails: command not found`.

Setting `path-type: inherit` on `setup-msys2` preserves the Windows PATH inside the msys2 shell, making `go` and `wails` visible while still keeping the MINGW64 `gcc` precedence we need for static linking.

## Changes

- `dev-build.yml` `build-gui-windows`: add `path-type: inherit` to setup-msys2.
- `release.yml` Windows GUI build: same.

## Test plan

- [ ] `build-gui-windows` job in dev-build runs `wails build` successfully.
- [ ] `verify-windows-gui-dlls` still passes (no `libstdc++-6.dll` / `libwinpthread-1.dll`).