### PR TITLE
ci: cancel stale in-progress workflow runs when a new one starts on main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.26'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "docs/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Docusaurus

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "main"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

- Adds a `concurrency` block to all workflows that trigger on `main` (dev-build, coverage, e2e, deploy, pull-request)
- Uses `group: ${{ github.workflow }}-${{ github.ref }}` so each workflow+ref pair gets its own slot
- Sets `cancel-in-progress: true` so a new push to `main` (or a PR branch) automatically cancels any in-progress run of the same workflow

`release.yml` is intentionally excluded — it only triggers on version tags, so duplicate runs aren't a concern.

## How it works

| Scenario | Behaviour |
|----------|-----------|
| Two commits pushed to `main` quickly | First run is cancelled when second starts |
| Two commits pushed to the same PR branch | First PR run is cancelled when second starts |
| Concurrent pushes to `main` and a PR | Each runs independently (different `github.ref`) |

## Test plan

- [ ] Push two commits to `main` in quick succession and confirm the first run is marked **Cancelled** in the Actions tab once the second starts
- [ ] Confirm the second run completes successfully end-to-end