### PR TITLE
fix(par2): skip PAR2 creation for files smaller than SIMD alignment

### DIFF
--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -218,18 +218,15 @@ func (p *NativeExecutor) createPar2ForFile(ctx context.Context, file fileinfo.Fi
 	// clamping to prevent buffer overreads and segfaults.
 	if file.Size > 0 && parBlockSize > file.Size {
 		const simdSafeAlignment = uint64(128)
-		if file.Size >= simdSafeAlignment {
-			parBlockSize = (file.Size / simdSafeAlignment) * simdSafeAlignment
-		} else {
-			// File too small for 128-byte alignment; round to nearest multiple of 4 (PAR2 spec)
-			parBlockSize = (file.Size / 4) * 4
-		}
-		if parBlockSize < 4 {
-			// File is smaller than minimum valid PAR2 slice size — skip creation
-			slog.WarnContext(ctx, "File too small for PAR2 creation, skipping",
+		if file.Size < simdSafeAlignment {
+			// File smaller than SIMD-safe alignment — par2go's C backend may read
+			// past the buffer end with sub-stride slice sizes, causing a segfault
+			// on AVX-512 hardware. Skip PAR2 creation for such tiny files.
+			slog.WarnContext(ctx, "File too small for SIMD-safe PAR2 creation, skipping",
 				"path", file.Path, "size", file.Size)
 			return nil, nil
 		}
+		parBlockSize = (file.Size / simdSafeAlignment) * simdSafeAlignment
 	}
 	// PAR2 spec requires slice size to be a multiple of 4
 	parBlockSize = alignDown(parBlockSize, 4)


### PR DESCRIPTION
## Summary

Fixes intermittent CI segfault in `internal/par2`:

```
INFO Starting par2 creation process executor=NativeExecutor
signal: segmentation fault (core dumped)
FAIL  github.com/javi11/postie/internal/par2  0.794s
```

## Root cause

The `par2go` C backend may read up to `stride-1` bytes past the input buffer when the slice size isn't a multiple of the SIMD stride (64 B on AVX-512). PR #189 fixed this for files ≥128 B by rounding the slice size down to a 128-byte boundary, but the `else` branch still passed sub-stride slices (e.g. 8 B for a 10-byte file) to the C library, causing segfaults on Linux x86_64 CI runners.

Crashes appeared "flaky" because the overrun only segfaults when the read crosses into an unmapped page — depends on heap layout, ASLR, and allocator state. The existing `defer recover()` in `TestIntegration_NativeExecutor_HandlesVerySmallFiles_10Bytes` cannot catch CGO segfaults (they bypass Go's panic mechanism). Locally on macOS the SIMD instruction path differs and the bug stays latent.

## Change

In `createPar2ForFile`, when `parBlockSize > file.Size` and `file.Size < 128`, skip PAR2 creation with a warning instead of computing a sub-stride slice. Files that small yield no meaningful recovery data, and the upload pipeline already tolerates a nil par2 result (file upload runs in a parallel goroutine, `poster.Post(ctx, nil, ...)` is a no-op).

The existing 10-byte regression test was already written assuming "skip" is a valid outcome (`"expect either a nil result (skipped with warning) or a graceful error, but never a panic"`).

## Test plan

- [x] `go test -race -count=1 ./internal/par2/...` passes locally
- [x] `TestIntegration_NativeExecutor_HandlesVerySmallFiles_10Bytes` now takes the skip path
- [x] `TestIntegration_NativeExecutor_HandlesVerySmallFiles_512Bytes` still creates PAR2 (≥128 B path unchanged)
- [ ] CI run on AVX-512 Linux: segfault gone