### PR TITLE
fix(logs): remove noisy debug log for app status

### DIFF
--- a/internal/backend/app.go
+++ b/internal/backend/app.go
@@ -478,8 +478,6 @@ func (a *App) GetAppStatus() AppStatus {
 		status.NeedsConfiguration = true
 	}
 
-	slog.Debug("Current application status", "status", status)
-
 	return status
 }
 


### PR DESCRIPTION
## Summary
- Removes a `slog.Debug` call in `GetAppStatus()` that logged the full `AppStatus` struct on every call, producing noisy `[object Object]` entries in the logs viewer.

## Test plan
- [ ] Open the logs page and verify the "Current application status" debug entry no longer appears