### PR TITLE
fix: use RFC1123Z (numeric offset) for Date header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/javi11/nntppool/v4 v4.9.0
+	github.com/javi11/nntppool/v4 v4.10.1
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.4
 	github.com/javi11/par2go v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackmordaunt/icns v1.0.0 h1:RYSxplerf/l/DUd09AHtITwckkv/mqjVv4DjYdPmAMQ=
 github.com/jackmordaunt/icns v1.0.0/go.mod h1:7TTQVEuGzVVfOPPlLNHJIkzA6CoV7aH1Dv9dW351oOo=
-github.com/javi11/nntppool/v4 v4.9.0 h1:HoAXUP6GhOPqsXIdHp5omqZ8ya8wD9zPbQyTmEmTuzM=
-github.com/javi11/nntppool/v4 v4.9.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.10.1 h1:NHoRniTnCRgpt/niljsWjA3gP5pYtNwxaqbLdr0Bcew=
+github.com/javi11/nntppool/v4 v4.10.1/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.4 h1:0aYyORZipp7iX8eNpT/efnzCeVO+9C0sE2HWCGc/JaI=

--- a/internal/article/article.go
+++ b/internal/article/article.go
@@ -94,7 +94,7 @@ func (a *Article) Encode(body []byte) (io.Reader, func(), error) {
 	headers["From"] = a.From
 	headers["Newsgroups"] = strings.Join(a.Groups, ",")
 	headers["Message-ID"] = fmt.Sprintf("<%s>", a.MessageID)
-	headers["Date"] = a.Date.UTC().Format(time.RFC1123)
+	headers["Date"] = a.Date.UTC().Format(time.RFC1123Z)
 
 	if a.XNxgHeader != "" {
 		headers["X-Nxg"] = a.XNxgHeader

--- a/internal/article/article_test.go
+++ b/internal/article/article_test.go
@@ -129,7 +129,7 @@ func TestEncode(t *testing.T) {
 	if !strings.Contains(result, "X-Test: Value") {
 		t.Error("Encoded output missing custom header")
 	}
-	if !strings.Contains(result, "Date: Sun, 01 Jan 2023 00:00:00 UTC") {
+	if !strings.Contains(result, "Date: Sun, 01 Jan 2023 00:00:00 +0000") {
 		t.Error("Encoded output missing Date header")
 	}
 

--- a/internal/poster/poster.go
+++ b/internal/poster/poster.go
@@ -1064,7 +1064,7 @@ func (p *poster) postArticleWithBody(ctx context.Context, art *article.Article, 
 	}
 
 	// Add Date header
-	headers.Extra["Date"] = []string{art.Date.UTC().Format(time.RFC1123)}
+	headers.Extra["Date"] = []string{art.Date.UTC().Format(time.RFC1123Z)}
 
 	// Add custom headers
 	if art.CustomHeaders != nil {


### PR DESCRIPTION
## Summary

`time.RFC1123` formats UTC times as `"Mon, 02 Jan 2006 15:04:05 UTC"`, but
RFC 5322 §3.3 requires the zone to be a numeric offset (`+0000`). Strict
Usenet backends (Astraweb and several Highwinds resellers) reject articles
with the literal `UTC` zone and respond 441.

This is a one-line fix in two places:

- [internal/article/article.go:97](internal/article/article.go) — header builder used for raw article rendering.
- [internal/poster/poster.go:1067](internal/poster/poster.go) — header passed to nntppool's `PostYenc`.

Test assertion in `article_test.go` updated to match the new format.

Companion change in [nntppool#65](https://github.com/javi11/nntppool/pull/65)
adds defensive validation/folding/RFC 2047 encoding on the library side.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/article/ ./internal/poster/` passes
- [ ] Manual smoke test against a previously-rejecting provider