### PR TITLE
feat(arr): auto-setup Radarr/Sonarr/Lidarr/Readarr import webhook in web mode

### DIFF
--- a/cmd/web/arr_handlers.go
+++ b/cmd/web/arr_handlers.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/javi11/postie/internal/arr"
+	"github.com/javi11/postie/internal/backend"
+	"github.com/javi11/postie/internal/config"
+)
+
+type addArrInstanceRequest struct {
+	Instance   config.ArrInstance `json:"instance"`
+	WebhookURL string             `json:"webhook_url"` // e.g. "http://postie:8080"
+}
+
+func (ws *WebServer) handleListArrInstances(w http.ResponseWriter, r *http.Request) {
+	instances, err := ws.app.GetArrInstances()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(instances)
+}
+
+func (ws *WebServer) handleAddArrInstance(w http.ResponseWriter, r *http.Request) {
+	var req addArrInstanceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Instance.ID == "" {
+		req.Instance.ID = uuid.NewString()
+	}
+
+	apiKey, err := ws.app.GetAPIKey()
+	if err != nil {
+		http.Error(w, "could not retrieve API key: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	webhookURL := fmt.Sprintf("%s/api/arr/webhook/%s?apiKey=%s",
+		strings.TrimRight(req.WebhookURL, "/"),
+		req.Instance.ID,
+		apiKey,
+	)
+
+	saved, err := ws.app.SetupArrWebhook(r.Context(), req.Instance, webhookURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(saved)
+}
+
+func (ws *WebServer) handleRemoveArrInstance(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	if err := ws.app.RemoveArrInstance(r.Context(), id); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (ws *WebServer) handleTestArrConnection(w http.ResponseWriter, r *http.Request) {
+	var instance config.ArrInstance
+	if err := json.NewDecoder(r.Body).Decode(&instance); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := ws.app.TestArrConnection(r.Context(), instance); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (ws *WebServer) handleArrWebhook(w http.ResponseWriter, r *http.Request) {
+	// Validate API key from query param — arr webhooks cannot send custom headers.
+	apiKey, err := ws.app.GetAPIKey()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	incoming := r.URL.Query().Get("apiKey")
+	if subtle.ConstantTimeCompare([]byte(incoming), []byte(apiKey)) != 1 {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	instanceID := mux.Vars(r)["instanceId"]
+
+	var payload arr.WebhookPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	paths := arr.ExtractFilePaths(payload)
+	if len(paths) == 0 {
+		// Test ping or unsupported event — acknowledge without queuing.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	instances, err := ws.app.GetArrInstances()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var instance *config.ArrInstance
+	for i := range instances {
+		if instances[i].ID == instanceID {
+			instance = &instances[i]
+			break
+		}
+	}
+	if instance == nil {
+		http.Error(w, "arr instance not found", http.StatusNotFound)
+		return
+	}
+
+	for _, path := range paths {
+		req := backend.APIQueueUploadRequest{
+			File:              path,
+			RelativePath:      filepath.Dir(path),
+			Priority:          0,
+			DeleteAfterUpload: instance.DeleteAfterUpload,
+		}
+		if _, err := ws.app.EnqueueAPIUpload(r.Context(), req); err != nil {
+			http.Error(w, fmt.Sprintf("queuing %s: %v", path, err), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -280,6 +280,14 @@ func (ws *WebServer) setupRoutes() {
 	api.HandleFunc("/watcher/status", ws.handleGetWatcherStatus).Methods("GET")
 	api.HandleFunc("/watcher/scan", ws.handleTriggerScan).Methods("POST")
 
+	// Arr webhook integration (web mode only — hidden in desktop UI)
+	api.HandleFunc("/arr/instances", ws.handleListArrInstances).Methods("GET")
+	api.HandleFunc("/arr/instances", ws.handleAddArrInstance).Methods("POST")
+	api.HandleFunc("/arr/instances/{id}", ws.handleRemoveArrInstance).Methods("DELETE")
+	api.HandleFunc("/arr/instances/{id}/test", ws.handleTestArrConnection).Methods("POST")
+	// Webhook receiver — API key validated from ?apiKey query param (arr can't send custom headers)
+	api.HandleFunc("/arr/webhook/{instanceId}", ws.handleArrWebhook).Methods("POST")
+
 	// API key management for the settings UI (open routes, same as other UI APIs)
 	api.HandleFunc("/api-key", ws.handleGetAPIKey).Methods("GET")
 	api.HandleFunc("/api-key/regenerate", ws.handleRegenerateAPIKey).Methods("POST")

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3,7 +3,8 @@
 import { browser } from "$app/environment";
 import type { backend, config, processor, watcher } from "$lib/wailsjs/go/models";
 // Using backend types for pagination - remove temporary types import
-import type { WebClient } from "./web-client";
+import type { ArrInstance, WebClient } from "./web-client";
+export type { ArrInstance };
 
 type WailsApp = typeof import("$lib/wailsjs/go/backend/App");
 type WailsRuntime = typeof import("$lib/wailsjs/runtime/runtime");
@@ -935,6 +936,52 @@ export class UnifiedClient {
 		}
 
 		throw new Error("No client available");
+	}
+
+	// ── Arr webhook integration (web mode only) ────────────────────────────
+
+	async getArrInstances(): Promise<ArrInstance[]> {
+		await this.initialize();
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.getArrInstances();
+		}
+
+		throw new Error("Arr webhook integration is only available in web mode");
+	}
+
+	async addArrInstance(instance: ArrInstance): Promise<ArrInstance> {
+		await this.initialize();
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.addArrInstance(instance);
+		}
+
+		throw new Error("Arr webhook integration is only available in web mode");
+	}
+
+	async removeArrInstance(id: string): Promise<void> {
+		await this.initialize();
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.removeArrInstance(id);
+		}
+
+		throw new Error("Arr webhook integration is only available in web mode");
+	}
+
+	async testArrConnection(instance: ArrInstance): Promise<void> {
+		await this.initialize();
+
+		if (this._environment === "web") {
+			const client = await getWebClient();
+			return client.testArrConnection(instance);
+		}
+
+		throw new Error("Arr webhook integration is only available in web mode");
 	}
 }
 

--- a/frontend/src/lib/api/web-client.ts
+++ b/frontend/src/lib/api/web-client.ts
@@ -5,6 +5,17 @@ import type { backend, config, processor, watcher } from "$lib/wailsjs/go/models
 
 const API_BASE = "/api";
 
+export interface ArrInstance {
+	id: string;
+	name: string;
+	type: "radarr" | "sonarr" | "lidarr" | "readarr";
+	url: string;
+	api_key: string;
+	enabled: boolean;
+	webhook_id: number;
+	delete_after_upload: boolean;
+}
+
 export class WebClient {
 	private ws: WebSocket | null = null;
 	private wsListeners: Map<string, (data: unknown) => void> = new Map();
@@ -497,6 +508,39 @@ export class WebClient {
 		a.click();
 		window.URL.revokeObjectURL(url);
 		document.body.removeChild(a);
+	}
+
+	// ── Arr webhook integration ─────────────────────────────────────────────
+
+	async getArrInstances(): Promise<ArrInstance[]> {
+		const res = await fetch(`${API_BASE}/arr/instances`);
+		if (!res.ok) throw new Error(await res.text());
+		return res.json();
+	}
+
+	async addArrInstance(instance: ArrInstance): Promise<ArrInstance> {
+		const webhookURL = window.location.origin;
+		const res = await fetch(`${API_BASE}/arr/instances`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ instance, webhook_url: webhookURL }),
+		});
+		if (!res.ok) throw new Error(await res.text());
+		return res.json();
+	}
+
+	async removeArrInstance(id: string): Promise<void> {
+		const res = await fetch(`${API_BASE}/arr/instances/${id}`, { method: "DELETE" });
+		if (!res.ok) throw new Error(await res.text());
+	}
+
+	async testArrConnection(instance: ArrInstance): Promise<void> {
+		const res = await fetch(`${API_BASE}/arr/instances/${instance.id}/test`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(instance),
+		});
+		if (!res.ok) throw new Error(await res.text());
 	}
 }
 

--- a/frontend/src/lib/components/settings/ArrSection.svelte
+++ b/frontend/src/lib/components/settings/ArrSection.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import { t } from '$lib/i18n';
+	import apiClient, { type ArrInstance } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast';
+
+	let instances = $state<ArrInstance[]>([]);
+	let showAddForm = $state(false);
+	let saving = $state(false);
+	let testingId = $state<string | null>(null);
+
+	function blankInstance(): ArrInstance {
+		return {
+			id: '',
+			name: '',
+			type: 'radarr',
+			url: '',
+			api_key: '',
+			enabled: true,
+			webhook_id: 0,
+			delete_after_upload: false
+		};
+	}
+
+	let draft = $state<ArrInstance>(blankInstance());
+
+	async function load() {
+		try {
+			instances = await apiClient.getArrInstances();
+		} catch (e) {
+			toastStore.error($t('arr.title'), String(e));
+		}
+	}
+
+	$effect(() => {
+		load();
+	});
+
+	async function testConnection(instance: ArrInstance) {
+		testingId = instance.id || 'draft';
+		try {
+			await apiClient.testArrConnection(instance);
+			toastStore.success($t('arr.connection_ok'));
+		} catch (e) {
+			toastStore.error($t('arr.error_test'), String(e));
+		} finally {
+			testingId = null;
+		}
+	}
+
+	async function setupWebhook() {
+		saving = true;
+		try {
+			const saved = await apiClient.addArrInstance(draft);
+			instances = [...instances, saved];
+			draft = blankInstance();
+			showAddForm = false;
+			toastStore.success($t('arr.webhook_created'));
+		} catch (e) {
+			toastStore.error($t('arr.error_setup'), String(e));
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function removeInstance(instance: ArrInstance) {
+		try {
+			await apiClient.removeArrInstance(instance.id);
+			instances = instances.filter((i) => i.id !== instance.id);
+			toastStore.success($t('arr.webhook_removed'));
+		} catch (e) {
+			toastStore.error($t('arr.error_remove'), String(e));
+		}
+	}
+
+	const ARR_TYPES: { value: ArrInstance['type']; label: string; port: number }[] = [
+		{ value: 'radarr', label: 'Radarr', port: 7878 },
+		{ value: 'sonarr', label: 'Sonarr', port: 8989 },
+		{ value: 'lidarr', label: 'Lidarr', port: 8686 },
+		{ value: 'readarr', label: 'Readarr', port: 8787 }
+	];
+
+	function applyTypeDefaults() {
+		const found = ARR_TYPES.find((t) => t.value === draft.type);
+		if (found && !draft.url) {
+			draft.url = `http://localhost:${found.port}`;
+		}
+	}
+</script>
+
+<div class="card bg-base-100 shadow-sm">
+	<div class="card-body space-y-4">
+		<div class="flex items-center justify-between">
+			<div>
+				<h3 class="card-title">{$t('arr.title')}</h3>
+				<p class="text-sm text-base-content/70">{$t('arr.description')}</p>
+			</div>
+			{#if !showAddForm}
+				<button class="btn btn-primary btn-sm" onclick={() => (showAddForm = true)}>
+					+ {$t('arr.add_instance')}
+				</button>
+			{/if}
+		</div>
+
+		{#if instances.length === 0 && !showAddForm}
+			<p class="text-sm text-base-content/50 italic">{$t('arr.no_instances')}</p>
+		{/if}
+
+		{#each instances as instance (instance.id)}
+			<div class="flex items-center justify-between rounded-lg border border-base-300 px-4 py-3">
+				<div>
+					<span class="font-medium">{instance.name}</span>
+					<span class="badge badge-ghost badge-sm ml-2">{instance.type}</span>
+					<p class="text-xs text-base-content/60 mt-0.5">{instance.url}</p>
+				</div>
+				<div class="flex gap-2">
+					<button
+						class="btn btn-ghost btn-xs"
+						disabled={testingId === instance.id}
+						onclick={() => testConnection(instance)}
+					>
+						{testingId === instance.id ? $t('arr.testing') : $t('arr.test_connection')}
+					</button>
+					<button
+						class="btn btn-error btn-xs btn-outline"
+						onclick={() => removeInstance(instance)}
+					>
+						{$t('arr.remove_instance')}
+					</button>
+				</div>
+			</div>
+		{/each}
+
+		{#if showAddForm}
+			<div class="rounded-lg border border-primary/30 bg-base-200 p-4 space-y-4">
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<label class="label" for="arr-name">
+							<span class="label-text">{$t('arr.instance_name')}</span>
+						</label>
+						<input
+							id="arr-name"
+							type="text"
+							class="input input-bordered w-full"
+							placeholder={$t('arr.instance_name_placeholder')}
+							bind:value={draft.name}
+						/>
+					</div>
+
+					<div>
+						<label class="label" for="arr-type">
+							<span class="label-text">{$t('arr.type')}</span>
+						</label>
+						<select
+							id="arr-type"
+							class="select select-bordered w-full"
+							bind:value={draft.type}
+							onchange={applyTypeDefaults}
+						>
+							{#each ARR_TYPES as arrType}
+								<option value={arrType.value}>{arrType.label}</option>
+							{/each}
+						</select>
+					</div>
+
+					<div>
+						<label class="label" for="arr-url">
+							<span class="label-text">{$t('arr.url')}</span>
+						</label>
+						<input
+							id="arr-url"
+							type="url"
+							class="input input-bordered w-full"
+							placeholder={$t('arr.url_placeholder')}
+							bind:value={draft.url}
+						/>
+					</div>
+
+					<div>
+						<label class="label" for="arr-apikey">
+							<span class="label-text">{$t('arr.api_key')}</span>
+						</label>
+						<input
+							id="arr-apikey"
+							type="password"
+							class="input input-bordered w-full"
+							placeholder={$t('arr.api_key_placeholder')}
+							bind:value={draft.api_key}
+						/>
+					</div>
+				</div>
+
+				<label class="flex items-center gap-2 cursor-pointer">
+					<input type="checkbox" class="checkbox checkbox-sm" bind:checked={draft.delete_after_upload} />
+					<span class="text-sm">{$t('arr.delete_after_upload')}</span>
+				</label>
+
+				<div class="flex gap-2 pt-2">
+					<button
+						class="btn btn-ghost btn-sm"
+						disabled={testingId === 'draft'}
+						onclick={() => testConnection(draft)}
+					>
+						{testingId === 'draft' ? $t('arr.testing') : $t('arr.test_connection')}
+					</button>
+					<button
+						class="btn btn-primary btn-sm"
+						disabled={saving || !draft.name || !draft.url || !draft.api_key}
+						onclick={setupWebhook}
+					>
+						{saving ? $t('arr.setting_up') : $t('arr.save_instance')}
+					</button>
+					<button
+						class="btn btn-ghost btn-sm"
+						onclick={() => {
+							showAddForm = false;
+							draft = blankInstance();
+						}}
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -497,5 +497,30 @@
 			"obfuscate_subject_description": "Obfuscate the subject line",
 			"obfuscate_filename_description": "Obfuscate filenames in posts"
 		}
+	},
+	"arr": {
+		"title": "Arr Integration",
+		"description": "Automatically queue files when Radarr, Sonarr, Lidarr, or Readarr imports them.",
+		"add_instance": "Add Instance",
+		"no_instances": "No *arr instances configured yet.",
+		"instance_name": "Instance name",
+		"instance_name_placeholder": "My Radarr",
+		"type": "Application type",
+		"url": "URL",
+		"url_placeholder": "http://localhost:7878",
+		"api_key": "API key",
+		"api_key_placeholder": "Your arr API key",
+		"delete_after_upload": "Delete file from library after upload",
+		"test_connection": "Test",
+		"save_instance": "Setup webhook",
+		"remove_instance": "Remove",
+		"testing": "Testing…",
+		"setting_up": "Setting up…",
+		"connection_ok": "Connection successful",
+		"webhook_created": "Webhook registered successfully",
+		"webhook_removed": "Instance removed",
+		"error_test": "Connection failed",
+		"error_setup": "Webhook setup failed",
+		"error_remove": "Could not remove instance"
 	}
 }

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -492,5 +492,30 @@
 				"info_message": "La configuración del proxy SOCKS5 se aplica por servidor. Incluya credenciales en la URL si es necesario."
 			}
 		}
+	},
+	"arr": {
+		"title": "Integración con Arr",
+		"description": "Pone en cola archivos automáticamente cuando Radarr, Sonarr, Lidarr o Readarr los importa.",
+		"add_instance": "Añadir instancia",
+		"no_instances": "Aún no hay instancias *arr configuradas.",
+		"instance_name": "Nombre de la instancia",
+		"instance_name_placeholder": "Mi Radarr",
+		"type": "Tipo de aplicación",
+		"url": "URL",
+		"url_placeholder": "http://localhost:7878",
+		"api_key": "Clave API",
+		"api_key_placeholder": "Tu clave API de arr",
+		"delete_after_upload": "Borrar archivo de la biblioteca después de subir",
+		"test_connection": "Probar",
+		"save_instance": "Configurar webhook",
+		"remove_instance": "Eliminar",
+		"testing": "Probando…",
+		"setting_up": "Configurando…",
+		"connection_ok": "Conexión exitosa",
+		"webhook_created": "Webhook registrado correctamente",
+		"webhook_removed": "Instancia eliminada",
+		"error_test": "Falló la conexión",
+		"error_setup": "Error al configurar el webhook",
+		"error_remove": "No se pudo eliminar la instancia"
 	}
 }

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -490,5 +490,30 @@
 				"info_message": "La configuration du proxy SOCKS5 est appliquée par serveur. Incluez les identifiants dans l'URL si nécessaire."
 			}
 		}
+	},
+	"arr": {
+		"title": "Intégration Arr",
+		"description": "Met automatiquement les fichiers en file d'attente quand Radarr, Sonarr, Lidarr ou Readarr les importe.",
+		"add_instance": "Ajouter une instance",
+		"no_instances": "Aucune instance *arr configurée.",
+		"instance_name": "Nom de l'instance",
+		"instance_name_placeholder": "Mon Radarr",
+		"type": "Type d'application",
+		"url": "URL",
+		"url_placeholder": "http://localhost:7878",
+		"api_key": "Clé API",
+		"api_key_placeholder": "Votre clé API arr",
+		"delete_after_upload": "Supprimer le fichier de la bibliothèque après l'envoi",
+		"test_connection": "Tester",
+		"save_instance": "Configurer le webhook",
+		"remove_instance": "Supprimer",
+		"testing": "Test en cours…",
+		"setting_up": "Configuration…",
+		"connection_ok": "Connexion réussie",
+		"webhook_created": "Webhook enregistré avec succès",
+		"webhook_removed": "Instance supprimée",
+		"error_test": "Échec de la connexion",
+		"error_setup": "Échec de la configuration du webhook",
+		"error_remove": "Impossible de supprimer l'instance"
 	}
 }

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -495,5 +495,30 @@
 			"obfuscate_subject_description": "Konu satırını gizle",
 			"obfuscate_filename_description": "Gönderilerdeki dosya adlarını gizle"
 		}
+	},
+	"arr": {
+		"title": "Arr Entegrasyonu",
+		"description": "Radarr, Sonarr, Lidarr veya Readarr bir dosyayı içe aktardığında otomatik olarak kuyruğa ekler.",
+		"add_instance": "Örnek Ekle",
+		"no_instances": "Henüz yapılandırılmış *arr örneği yok.",
+		"instance_name": "Örnek adı",
+		"instance_name_placeholder": "Radarr'ım",
+		"type": "Uygulama türü",
+		"url": "URL",
+		"url_placeholder": "http://localhost:7878",
+		"api_key": "API anahtarı",
+		"api_key_placeholder": "arr API anahtarınız",
+		"delete_after_upload": "Yüklemeden sonra dosyayı kitaplıktan sil",
+		"test_connection": "Test Et",
+		"save_instance": "Webhook kur",
+		"remove_instance": "Kaldır",
+		"testing": "Test ediliyor…",
+		"setting_up": "Ayarlanıyor…",
+		"connection_ok": "Bağlantı başarılı",
+		"webhook_created": "Webhook başarıyla kaydedildi",
+		"webhook_removed": "Örnek kaldırıldı",
+		"error_test": "Bağlantı başarısız",
+		"error_setup": "Webhook kurulumu başarısız",
+		"error_remove": "Örnek kaldırılamadı"
 	}
 }

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -15,6 +15,7 @@ import PostUploadScriptSection from "$lib/components/settings/PostUploadScriptSe
 import QueueSection from "$lib/components/settings/QueueSection.svelte";
 import ServerSection from "$lib/components/settings/ServerSection.svelte";
 import WatcherSection from "$lib/components/settings/WatcherSection.svelte";
+import ArrSection from "$lib/components/settings/ArrSection.svelte";
 import { t } from "$lib/i18n";
 import { advancedMode, appStatus, settingsSaveFunction } from "$lib/stores/app";
 import { toastStore } from "$lib/stores/toast";
@@ -368,6 +369,9 @@ onDestroy(() => {
               <WatcherSection bind:config={localConfig} />
               <PostUploadScriptSection bind:config={localConfig} />
               <ApiSection bind:config={localConfig} />
+              {#if apiClient.environment !== 'wails'}
+                <ArrSection />
+              {/if}
             </div>
           </div>
         </div>

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
 	golang.org/x/sync v0.19.0
+	golift.io/starr v1.3.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	maragu.dev/goqite v0.3.2-0.20250625131501-cacb23e73698
@@ -125,7 +126,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/image v0.12.0 // indirect
-	golift.io/starr v1.3.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	howett.net/plist v1.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/image v0.12.0 // indirect
+	golift.io/starr v1.3.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	howett.net/plist v1.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -862,6 +862,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golift.io/starr v1.3.1 h1:+Hv4abYcrom+7OZS96OV0r9HJrgdIcqYy/lMsXmUbLQ=
+golift.io/starr v1.3.1/go.mod h1:ZmfSxCqxOR2Uh+jbyde3jSPIfHgmFB/B0GmlbBZU74w=
 google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/arr/client.go
+++ b/internal/arr/client.go
@@ -1,0 +1,158 @@
+package arr
+
+import (
+	"context"
+	"fmt"
+
+	"golift.io/starr"
+	"golift.io/starr/lidarr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/readarr"
+	"golift.io/starr/sonarr"
+
+	"github.com/javi11/postie/internal/config"
+)
+
+const notificationName = "Postie"
+
+// SetupWebhook registers a Postie webhook notification with the target *arr
+// app using its native API. Returns the notification ID created in the arr app,
+// which must be saved to ArrInstance.WebhookID for later removal.
+// webhookURL must be the full Postie URL including the ?apiKey query param.
+func SetupWebhook(ctx context.Context, instance config.ArrInstance, webhookURL string) (int64, error) {
+	cfg := &starr.Config{
+		APIKey: instance.APIKey,
+		URL:    instance.URL,
+	}
+
+	fields := []*starr.FieldInput{
+		{Name: "url", Value: webhookURL},
+		{Name: "method", Value: 2}, // 2 = POST
+	}
+
+	switch instance.Type {
+	case config.ArrTypeRadarr:
+		return setupRadarrWebhook(ctx, radarr.New(cfg), fields)
+	case config.ArrTypeSonarr:
+		return setupSonarrWebhook(ctx, sonarr.New(cfg), fields)
+	case config.ArrTypeLidarr:
+		return setupLidarrWebhook(ctx, lidarr.New(cfg), fields)
+	case config.ArrTypeReadarr:
+		return setupReadarrWebhook(ctx, readarr.New(cfg), fields)
+	default:
+		return 0, fmt.Errorf("unsupported arr type: %q", instance.Type)
+	}
+}
+
+func setupRadarrWebhook(ctx context.Context, client *radarr.Radarr, fields []*starr.FieldInput) (int64, error) {
+	out, err := client.AddNotificationContext(ctx, &radarr.NotificationInput{
+		Name:           notificationName,
+		OnDownload:     true,
+		OnUpgrade:      true,
+		Implementation: "Webhook",
+		ConfigContract: "WebhookSettings",
+		Fields:         fields,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("radarr AddNotification: %w", err)
+	}
+	return out.ID, nil
+}
+
+func setupSonarrWebhook(ctx context.Context, client *sonarr.Sonarr, fields []*starr.FieldInput) (int64, error) {
+	out, err := client.AddNotificationContext(ctx, &sonarr.NotificationInput{
+		Name:           notificationName,
+		OnDownload:     true,
+		OnUpgrade:      true,
+		Implementation: "Webhook",
+		ConfigContract: "WebhookSettings",
+		Fields:         fields,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("sonarr AddNotification: %w", err)
+	}
+	return out.ID, nil
+}
+
+func setupLidarrWebhook(ctx context.Context, client *lidarr.Lidarr, fields []*starr.FieldInput) (int64, error) {
+	out, err := client.AddNotificationContext(ctx, &lidarr.NotificationInput{
+		Name:             notificationName,
+		OnReleaseImport:  true, // Lidarr uses OnReleaseImport, not OnDownload
+		OnUpgrade:        true,
+		Implementation:   "Webhook",
+		ConfigContract:   "WebhookSettings",
+		Fields:           fields,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("lidarr AddNotification: %w", err)
+	}
+	return out.ID, nil
+}
+
+func setupReadarrWebhook(ctx context.Context, client *readarr.Readarr, fields []*starr.FieldInput) (int64, error) {
+	out, err := client.AddNotificationContext(ctx, &readarr.NotificationInput{
+		Name:             notificationName,
+		OnReleaseImport:  true, // Readarr uses OnReleaseImport, not OnDownload
+		OnUpgrade:        true,
+		Implementation:   "Webhook",
+		ConfigContract:   "WebhookSettings",
+		Fields:           fields,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("readarr AddNotification: %w", err)
+	}
+	return out.ID, nil
+}
+
+// RemoveWebhook deletes the Postie notification from the arr app using the
+// stored WebhookID. No-op if WebhookID is 0.
+func RemoveWebhook(ctx context.Context, instance config.ArrInstance) error {
+	if instance.WebhookID == 0 {
+		return nil
+	}
+
+	cfg := &starr.Config{
+		APIKey: instance.APIKey,
+		URL:    instance.URL,
+	}
+
+	switch instance.Type {
+	case config.ArrTypeRadarr:
+		return radarr.New(cfg).DeleteNotificationContext(ctx, instance.WebhookID)
+	case config.ArrTypeSonarr:
+		return sonarr.New(cfg).DeleteNotificationContext(ctx, instance.WebhookID)
+	case config.ArrTypeLidarr:
+		return lidarr.New(cfg).DeleteNotificationContext(ctx, instance.WebhookID)
+	case config.ArrTypeReadarr:
+		return readarr.New(cfg).DeleteNotificationContext(ctx, instance.WebhookID)
+	default:
+		return fmt.Errorf("unsupported arr type: %q", instance.Type)
+	}
+}
+
+// TestConnection verifies the arr instance is reachable and the API key is valid.
+func TestConnection(ctx context.Context, instance config.ArrInstance) error {
+	cfg := &starr.Config{
+		APIKey: instance.APIKey,
+		URL:    instance.URL,
+	}
+
+	var err error
+	switch instance.Type {
+	case config.ArrTypeRadarr:
+		_, err = radarr.New(cfg).GetSystemStatusContext(ctx)
+	case config.ArrTypeSonarr:
+		_, err = sonarr.New(cfg).GetSystemStatusContext(ctx)
+	case config.ArrTypeLidarr:
+		_, err = lidarr.New(cfg).GetSystemStatusContext(ctx)
+	case config.ArrTypeReadarr:
+		_, err = readarr.New(cfg).GetSystemStatusContext(ctx)
+	default:
+		return fmt.Errorf("unsupported arr type: %q", instance.Type)
+	}
+
+	if err != nil {
+		return fmt.Errorf("arr connection test failed: %w", err)
+	}
+	return nil
+}

--- a/internal/arr/webhook.go
+++ b/internal/arr/webhook.go
@@ -1,0 +1,57 @@
+package arr
+
+// WebhookPayload is a unified struct covering the import event payloads from
+// Radarr, Sonarr, Lidarr, and Readarr. Fields unused by a given app are nil/empty.
+type WebhookPayload struct {
+	EventType   string              `json:"eventType"`
+	MovieFile   *MovieFilePayload   `json:"movieFile,omitempty"`
+	EpisodeFile *EpisodeFilePayload `json:"episodeFile,omitempty"`
+	TrackFiles  []TrackFilePayload  `json:"trackFiles,omitempty"`
+	BookFiles   []BookFilePayload   `json:"bookFiles,omitempty"`
+}
+
+type MovieFilePayload struct {
+	Path string `json:"path"`
+}
+
+type EpisodeFilePayload struct {
+	Path string `json:"path"`
+}
+
+type TrackFilePayload struct {
+	Path string `json:"path"`
+}
+
+type BookFilePayload struct {
+	Path string `json:"path"`
+}
+
+// ExtractFilePaths returns the final library file paths from a webhook payload.
+// Returns nil when EventType is not "Download" — arr fires this event only after
+// the file has been renamed and moved to its final library destination.
+func ExtractFilePaths(payload WebhookPayload) []string {
+	if payload.EventType != "Download" {
+		return nil
+	}
+
+	var paths []string
+
+	if payload.MovieFile != nil && payload.MovieFile.Path != "" {
+		paths = append(paths, payload.MovieFile.Path)
+	}
+	if payload.EpisodeFile != nil && payload.EpisodeFile.Path != "" {
+		paths = append(paths, payload.EpisodeFile.Path)
+	}
+	for _, tf := range payload.TrackFiles {
+		if tf.Path != "" {
+			paths = append(paths, tf.Path)
+		}
+	}
+	for _, bf := range payload.BookFiles {
+		if bf.Path != "" {
+			paths = append(paths, bf.Path)
+		}
+	}
+
+	return paths
+}

--- a/internal/arr/webhook_test.go
+++ b/internal/arr/webhook_test.go
@@ -1,0 +1,58 @@
+package arr_test
+
+import (
+	"testing"
+
+	"github.com/javi11/postie/internal/arr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractFilePaths_Radarr(t *testing.T) {
+	payload := arr.WebhookPayload{
+		EventType: "Download",
+		MovieFile: &arr.MovieFilePayload{Path: "/movies/The.Matrix.1999.mkv"},
+	}
+	got := arr.ExtractFilePaths(payload)
+	assert.Equal(t, []string{"/movies/The.Matrix.1999.mkv"}, got)
+}
+
+func TestExtractFilePaths_Sonarr(t *testing.T) {
+	payload := arr.WebhookPayload{
+		EventType:   "Download",
+		EpisodeFile: &arr.EpisodeFilePayload{Path: "/tv/Breaking.Bad.S01E01.mkv"},
+	}
+	got := arr.ExtractFilePaths(payload)
+	assert.Equal(t, []string{"/tv/Breaking.Bad.S01E01.mkv"}, got)
+}
+
+func TestExtractFilePaths_Lidarr(t *testing.T) {
+	payload := arr.WebhookPayload{
+		EventType: "Download",
+		TrackFiles: []arr.TrackFilePayload{
+			{Path: "/music/Artist/01.flac"},
+			{Path: "/music/Artist/02.flac"},
+		},
+	}
+	got := arr.ExtractFilePaths(payload)
+	assert.Equal(t, []string{"/music/Artist/01.flac", "/music/Artist/02.flac"}, got)
+}
+
+func TestExtractFilePaths_Readarr(t *testing.T) {
+	payload := arr.WebhookPayload{
+		EventType: "Download",
+		BookFiles: []arr.BookFilePayload{
+			{Path: "/books/Author/Book.epub"},
+		},
+	}
+	got := arr.ExtractFilePaths(payload)
+	assert.Equal(t, []string{"/books/Author/Book.epub"}, got)
+}
+
+func TestExtractFilePaths_TestEventIgnored(t *testing.T) {
+	payload := arr.WebhookPayload{
+		EventType: "Test",
+		MovieFile: &arr.MovieFilePayload{Path: "/movies/some.mkv"},
+	}
+	got := arr.ExtractFilePaths(payload)
+	assert.Empty(t, got)
+}

--- a/internal/backend/arr.go
+++ b/internal/backend/arr.go
@@ -1,0 +1,79 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/javi11/postie/internal/arr"
+	"github.com/javi11/postie/internal/config"
+)
+
+// SetupArrWebhook registers a Postie import webhook with the given arr instance,
+// persists the instance (with the returned WebhookID) to config, and saves config.
+// webhookURL must be the full URL Postie is reachable at, including the ?apiKey
+// query param so arr can authenticate the call.
+func (a *App) SetupArrWebhook(ctx context.Context, instance config.ArrInstance, webhookURL string) (config.ArrInstance, error) {
+	id, err := arr.SetupWebhook(ctx, instance, webhookURL)
+	if err != nil {
+		return instance, fmt.Errorf("setting up arr webhook: %w", err)
+	}
+	instance.WebhookID = id
+	instance.Enabled = true
+
+	cfg, err := a.GetConfig()
+	if err != nil {
+		return instance, err
+	}
+	cfg.Arr.Instances = append(cfg.Arr.Instances, instance)
+	if err := a.SaveConfig(cfg); err != nil {
+		return instance, err
+	}
+	return instance, nil
+}
+
+// RemoveArrInstance removes the arr webhook from the app and deletes the
+// instance from config. If the webhook cannot be removed from arr (e.g. the
+// arr instance is unreachable), the instance is still removed from config.
+func (a *App) RemoveArrInstance(ctx context.Context, instanceID string) error {
+	cfg, err := a.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	idx := -1
+	for i, inst := range cfg.Arr.Instances {
+		if inst.ID == instanceID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("arr instance %q not found", instanceID)
+	}
+
+	instance := cfg.Arr.Instances[idx]
+	if removeErr := arr.RemoveWebhook(ctx, instance); removeErr != nil {
+		slog.Warn("could not remove arr webhook from remote app", "instanceID", instanceID, "error", removeErr)
+	}
+
+	cfg.Arr.Instances = append(cfg.Arr.Instances[:idx], cfg.Arr.Instances[idx+1:]...)
+	return a.SaveConfig(cfg)
+}
+
+// GetArrInstances returns all configured arr instances.
+func (a *App) GetArrInstances() ([]config.ArrInstance, error) {
+	cfg, err := a.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Arr.Instances == nil {
+		return []config.ArrInstance{}, nil
+	}
+	return cfg.Arr.Instances, nil
+}
+
+// TestArrConnection verifies the given arr instance is reachable and the API key is valid.
+func (a *App) TestArrConnection(ctx context.Context, instance config.ArrInstance) error {
+	return arr.TestConnection(ctx, instance)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,6 +190,7 @@ type ConfigData struct {
 	OutputDir                 string                 `yaml:"output_dir" json:"output_dir"`
 	MaintainOriginalExtension *bool                  `yaml:"maintain_original_extension" json:"maintain_original_extension"`
 	PostUploadScript          PostUploadScriptConfig `yaml:"post_upload_script" json:"post_upload_script"`
+	Arr                       ArrConfig              `yaml:"arr,omitempty" json:"arr,omitempty"`
 }
 
 type Par2Config struct {
@@ -380,6 +381,33 @@ type PostUploadScriptConfig struct {
 	MaxRetryDuration Duration `yaml:"max_retry_duration" json:"max_retry_duration"`
 	// How often to check for pending retries. Default value is `1m`.
 	RetryCheckInterval Duration `yaml:"retry_check_interval" json:"retry_check_interval"`
+}
+
+// ArrType identifies which *arr application an instance belongs to.
+type ArrType string
+
+const (
+	ArrTypeRadarr  ArrType = "radarr"
+	ArrTypeSonarr  ArrType = "sonarr"
+	ArrTypeLidarr  ArrType = "lidarr"
+	ArrTypeReadarr ArrType = "readarr"
+)
+
+// ArrInstance holds connection info and webhook state for a single *arr app.
+type ArrInstance struct {
+	ID                string  `yaml:"id"                  json:"id"`
+	Name              string  `yaml:"name"                json:"name"`
+	Type              ArrType `yaml:"type"                json:"type"`
+	URL               string  `yaml:"url"                 json:"url"`
+	APIKey            string  `yaml:"api_key"             json:"api_key"`
+	Enabled           bool    `yaml:"enabled"             json:"enabled"`
+	WebhookID         int64   `yaml:"webhook_id"          json:"webhook_id"`
+	DeleteAfterUpload bool    `yaml:"delete_after_upload" json:"delete_after_upload"`
+}
+
+// ArrConfig holds all configured *arr instances.
+type ArrConfig struct {
+	Instances []ArrInstance `yaml:"instances" json:"instances"`
 }
 
 // ProgressStatus represents the progress of file processing operations


### PR DESCRIPTION
## Summary

- Adds a new **Arr Integration** section to Settings → Automation (web mode only, hidden in desktop/Wails mode) that lets users register a Postie webhook with Radarr, Sonarr, Lidarr, or Readarr
- When an arr app imports a file (moving it to its final library path), it fires a webhook that automatically enqueues that file for upload in Postie
- Webhook URL is authenticated via `?apiKey=` query param (arr webhooks can't send custom headers); key is validated with `crypto/subtle.ConstantTimeCompare`

## What changed

**Go backend**
- `go.mod` / `go.sum`: added `golift.io/starr v1.3.1`
- `internal/config/config.go`: new `ArrInstance`, `ArrConfig`, `ArrType` types; `Arr ArrConfig` field on `ConfigData`
- `internal/arr/webhook.go`: unified `WebhookPayload` parser for all four arr apps — returns file paths only for `Download` events (Lidarr/Readarr fire `OnReleaseImport`)
- `internal/arr/webhook_test.go`: 5 unit tests (Radarr, Sonarr, Lidarr, Readarr, Test-event-ignored) — all pass
- `internal/arr/client.go`: `SetupWebhook`, `RemoveWebhook`, `TestConnection` via golift/starr
- `internal/backend/arr.go`: App-level methods (`SetupArrWebhook`, `RemoveArrInstance`, `GetArrInstances`, `TestArrConnection`)
- `cmd/web/arr_handlers.go`: 5 HTTP handlers registered under `/api/arr/...`

**Frontend**
- `web-client.ts` / `client.ts`: `getArrInstances`, `addArrInstance`, `removeArrInstance`, `testArrConnection` (web-only; throws in wails mode)
- `locales/{en,es,fr,tr}/settings.json`: arr section translations in all 4 languages
- `ArrSection.svelte`: add/test/remove arr instances with daisyUI form
- `settings/+page.svelte`: mounts `<ArrSection />` inside Automation tab only when `apiClient.environment !== 'wails'`

## Test Plan

- [ ] Run `go test ./internal/arr/...` — all 5 tests pass
- [ ] Start Postie web mode (`go run ./cmd/web/main.go`), navigate to Settings → Automation — "Arr Integration" section visible
- [ ] Add a Radarr instance, click Test — toast shows "Connection successful"
- [ ] Click "Setup webhook" — webhook appears in Radarr → Settings → Connect
- [ ] POST a `Download` event to `/api/arr/webhook/{id}?apiKey=...` — file queued in Postie
- [ ] Click Remove — webhook removed from Radarr
- [ ] Open Postie in Wails desktop mode — Arr Integration section must NOT appear