### PR TITLE
feat(poster): bump nntppool to v4.11.1 and use PostHeaders.Date field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/javi11/nntppool/v4 v4.10.1
+	github.com/javi11/nntppool/v4 v4.11.1
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.4
 	github.com/javi11/par2go v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/jackmordaunt/icns v1.0.0 h1:RYSxplerf/l/DUd09AHtITwckkv/mqjVv4DjYdPmA
 github.com/jackmordaunt/icns v1.0.0/go.mod h1:7TTQVEuGzVVfOPPlLNHJIkzA6CoV7aH1Dv9dW351oOo=
 github.com/javi11/nntppool/v4 v4.10.1 h1:NHoRniTnCRgpt/niljsWjA3gP5pYtNwxaqbLdr0Bcew=
 github.com/javi11/nntppool/v4 v4.10.1/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.11.1 h1:581fZSPv+RyIKY2hI0GB0eZrm1rCbAp+HRP5nIp7kd0=
+github.com/javi11/nntppool/v4 v4.11.1/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.4 h1:0aYyORZipp7iX8eNpT/efnzCeVO+9C0sE2HWCGc/JaI=

--- a/internal/poster/poster.go
+++ b/internal/poster/poster.go
@@ -1060,11 +1060,9 @@ func (p *poster) postArticleWithBody(ctx context.Context, art *article.Article, 
 		Subject:    art.Subject,
 		Newsgroups: art.Groups,
 		MessageID:  fmt.Sprintf("<%s>", art.MessageID),
+		Date:       art.Date.UTC(),
 		Extra:      make(map[string][]string),
 	}
-
-	// Add Date header
-	headers.Extra["Date"] = []string{art.Date.UTC().Format(time.RFC1123Z)}
 
 	// Add custom headers
 	if art.CustomHeaders != nil {


### PR DESCRIPTION
## Summary

- Bumps `nntppool` from v4.10.1 to v4.11.1
- Moves the article date out of `Extra["Date"]` (pre-formatted string) and into the new `PostHeaders.Date time.Time` field introduced in v4.11.1
- The library now handles RFC-compliant date formatting internally, falling back to `time.Now().UTC()` if the field is zero

## What changed

`internal/poster/poster.go` — `postArticleWithBody`:

```go
// Before
headers := nntppool.PostHeaders{ ... }
headers.Extra["Date"] = []string{art.Date.UTC().Format(time.RFC1123Z)}

// After
headers := nntppool.PostHeaders{
    ...
    Date:  art.Date.UTC(),
    ...
}
```

## Reviewer notes

Behaviour is identical — the article date is still applied to every outgoing article. The only difference is that formatting is now delegated to the library, which is the idiomatic way per the v4.11.1 `PostHeaders` documentation.

## Test plan

- [x] `go build ./internal/poster/...` — clean
- [x] `go test ./internal/poster/...` — all tests pass