### PR TITLE
fix(par2): fall back to article-size block when SliceSize exceeds file size

### DIFF
--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -206,9 +206,13 @@ func (p *NativeExecutor) CreateInDirectory(ctx context.Context, files []fileinfo
 // createPar2ForFile creates PAR2 files for a single input file in the given directory.
 func (p *NativeExecutor) createPar2ForFile(ctx context.Context, file fileinfo.FileInfo, dirPath string) ([]string, error) {
 	var parBlockSize uint64
-	if p.cfg.SliceSize > 0 {
+	if p.cfg.SliceSize > 0 && uint64(p.cfg.SliceSize) <= file.Size {
 		parBlockSize = uint64(p.cfg.SliceSize)
 	} else {
+		// Configured SliceSize exceeds file size (or is unset): fall back to
+		// article-size-based calculation. Clamping SliceSize to ≈file.Size
+		// creates only 1-2 slices with a nearly-zero last slice, which triggers
+		// undefined behavior in the ParPar C SIMD backend on Linux x86_64 (AVX-512).
 		parBlockSize = calculateParBlockSize(file.Size, p.articleSize)
 	}
 	// Guard: block size must not exceed file size AND must be SIMD-aligned.


### PR DESCRIPTION
## Summary

- Fixes segfault in `internal/par2` on Linux CI ([run #25039127340](https://github.com/javi11/postie/actions/runs/25039127340/job/73338093477))
- When configured `SliceSize > file.Size`, the previous code clamped to `(file.Size/128)*128 ≈ file.Size`, creating only 1–2 input slices with a near-zero last slice — a pathological configuration that triggers undefined behavior in the ParPar C SIMD backend (AVX-512) on Linux x86_64
- Fix: skip the configured `SliceSize` when it exceeds the file and fall back to `calculateParBlockSize()`, which produces a sensible number of equal slices (same as par2go's own tests use)

## Test plan

- [ ] All `./internal/par2/...` unit tests pass locally (`ok` in 0.6s)
- [ ] `TestIntegration_NativeExecutor_RegeneratesWhenNoPar2FilesExist` (the previously crashing test) should now pass on Linux CI
- [ ] No behavior change for large files where `SliceSize <= file.Size`