### PR TITLE
fix(config): apply Par2 config changes without requiring app restart

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -206,6 +206,52 @@ func (a *App) processorConfigChanged(newConfig *config.ConfigData) bool {
 		return true
 	}
 
+	if a.par2ConfigChanged(newConfig) {
+		return true
+	}
+
+	return false
+}
+
+func equalBoolPtr(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// par2ConfigChanged reports whether any Par2Config field has changed. Par2
+// settings are captured by Postie when each job starts, so flipping any of
+// them (in particular ParparBinaryPath, which selects the native vs. external
+// par2 executor) requires reinitializing the processor.
+func (a *App) par2ConfigChanged(newConfig *config.ConfigData) bool {
+	if a.config == nil {
+		return true
+	}
+	oldP := a.config.Par2
+	newP := newConfig.Par2
+
+	if !equalBoolPtr(oldP.Enabled, newP.Enabled) ||
+		!equalBoolPtr(oldP.MaintainPar2Files, newP.MaintainPar2Files) ||
+		!equalBoolPtr(oldP.SkipIfPar2Exists, newP.SkipIfPar2Exists) {
+		return true
+	}
+	if oldP.Redundancy != newP.Redundancy ||
+		oldP.TempDir != newP.TempDir ||
+		oldP.ParparBinaryPath != newP.ParparBinaryPath ||
+		oldP.NumGoroutines != newP.NumGoroutines ||
+		oldP.MemoryLimit != newP.MemoryLimit ||
+		oldP.SliceSize != newP.SliceSize {
+		return true
+	}
+	if len(oldP.ParparExtraArgs) != len(newP.ParparExtraArgs) {
+		return true
+	}
+	for i := range newP.ParparExtraArgs {
+		if oldP.ParparExtraArgs[i] != newP.ParparExtraArgs[i] {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
## Summary

- Changes to any `Par2Config` field (e.g. `ParparBinaryPath`, `Enabled`, `Redundancy`) now take effect immediately when the user saves settings — no app restart required.
- Adds `par2ConfigChanged` to `internal/backend/config.go` and hooks it into `processorConfigChanged` so Par2 edits flip `procNeedsRestart` and trigger `initializeProcessor` through the existing reload pathway.

## Why

`applyConfigChanges` only restarts the processor when a captured-at-init field changes. Par2 settings are captured by Postie at the start of each job (via `par2.NewExecutor`, which picks the native vs. external `parpar` executor based on `ParparBinaryPath`), but the processor itself holds a stale config snapshot until reinitialized. Without explicit detection of Par2 changes, edits silently persisted to disk while the running process kept using the old executor — forcing a manual restart.

The alternatives (reading `ParparBinaryPath` dynamically per invocation inside `BinaryExecutor`, or unconditionally restarting the processor on every save) were rejected as either more invasive or too disruptive to in-flight processing for unrelated edits.

## Test plan

- [ ] `go vet ./internal/backend/...` passes
- [ ] `go build ./internal/backend/...` passes
- [ ] With `par2.parpar_binary_path` empty, queue an upload → native par2 executor used
- [ ] Set `par2.parpar_binary_path` in Settings → Par2, save → processor reinit logged (no "Processor-relevant config unchanged" message)
- [ ] Queue another upload → external `parpar` executor used (visible in `exec.CommandContext` call in `internal/par2/binary.go`)
- [ ] Toggle `Enabled` off → next upload skips Par2 generation
- [ ] Verify the same behavior in web mode (`cmd/web`), since `applyConfigChanges` is shared