### PR TITLE
fix(poster): harden upload pipeline against deadlocks, panics, and throttle races

### DIFF
--- a/internal/poster/poster.go
+++ b/internal/poster/poster.go
@@ -40,6 +40,16 @@ var (
 // (slightly larger than the default article size of 750KB).
 const defaultBodyBufferSize = 768 * 1024
 
+// readAtStallTimeout bounds a single ReadAt call. *os.File.ReadAt is not
+// cancellable via context (Go limitation on regular files), so when the
+// underlying mount stalls — NFS, sleeping external drive, FUSE backend —
+// the read-ahead goroutine would otherwise hang forever, holding a buffer
+// and blocking the upload pipeline. We surface a clean error after this
+// deadline so the post fails instead of deadlocking. The OS-level read
+// goroutine itself still leaks until the kernel returns, but the upload
+// pipeline keeps moving and operators get a clear log line.
+const readAtStallTimeout = 60 * time.Second
+
 // maxBodyBufferPoolSize is the upper bound on buffers we accept back into the
 // pool. Anything larger came from an anomalously large article and would
 // permanently inflate the pool's working set if reused, so we drop it.
@@ -50,6 +60,32 @@ var bodyBufferPool = sync.Pool{
 	New: func() any {
 		return make([]byte, defaultBodyBufferSize)
 	},
+}
+
+// readAtWithStallGuard performs file.ReadAt under a wall-clock deadline. If
+// ReadAt does not return within readAtStallTimeout (e.g. the backing mount is
+// unresponsive), it returns a stall error so the caller can fail the post
+// cleanly instead of blocking the upload pipeline forever. The inner
+// goroutine still blocks until the OS releases ReadAt; this is a fundamental
+// Go limitation for regular files.
+func readAtWithStallGuard(ctx context.Context, file *os.File, buf []byte, off int64) (int, error) {
+	type result struct {
+		n   int
+		err error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		n, err := file.ReadAt(buf, off)
+		resCh <- result{n: n, err: err}
+	}()
+	select {
+	case r := <-resCh:
+		return r.n, r.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-time.After(readAtStallTimeout):
+		return 0, fmt.Errorf("read stalled after %s at offset %d (filesystem unresponsive?)", readAtStallTimeout, off)
+	}
 }
 
 // putBodyBuffer returns a buffer to the pool, dropping it if it grew beyond
@@ -499,7 +535,7 @@ func (p *poster) postLoop(ctx context.Context, postQueue chan *Post, checkQueue 
 						}
 						body := poolBuf[:art.Size]
 
-						if _, err := post.file.ReadAt(body, art.Offset); err != nil {
+						if _, err := readAtWithStallGuard(postCtx, post.file, body, art.Offset); err != nil {
 							putBodyBuffer(poolBuf)
 							slog.ErrorContext(ctx, "Error pre-reading article", "error", err, "offset", art.Offset)
 							return
@@ -630,7 +666,20 @@ func (p *poster) postLoop(ctx context.Context, postQueue chan *Post, checkQueue 
 			post.mu.Unlock()
 
 			if p.checkCfg.Enabled != nil && *p.checkCfg.Enabled {
-				checkQueue <- post
+				// Guard the send: if checkLoop has already exited (e.g. on a
+				// verify error) the buffered checkQueue can fill and this send
+				// would block forever, leaking postLoop and every queued post.
+				select {
+				case checkQueue <- post:
+				case <-ctx.Done():
+					if post.file != nil {
+						if cerr := post.file.Close(); cerr != nil {
+							slog.WarnContext(ctx, "Error closing file after ctx canceled during check enqueue", "error", cerr, "file", post.FilePath)
+						}
+					}
+					postsInFlight.Done()
+					post.wg.Done()
+				}
 
 				continue
 			}
@@ -981,6 +1030,10 @@ func (p *poster) addPost(ctx context.Context, filePath string, displayName strin
 
 	switch p.cfg.GroupPolicy {
 	case config.GroupPolicyEachFile:
+		if len(p.cfg.Groups) == 0 {
+			_ = file.Close()
+			return fmt.Errorf("group policy is %q but no newsgroups are configured", config.GroupPolicyEachFile)
+		}
 		randomGroup := p.cfg.Groups[rand.Intn(len(p.cfg.Groups))]
 		groups = append(groups, randomGroup.Name)
 	case config.GroupPolicyAll:

--- a/internal/poster/throttle.go
+++ b/internal/poster/throttle.go
@@ -1,18 +1,22 @@
 package poster
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 )
 
-// Throttle handles rate limiting using lock-free atomic operations
-// for better performance under high concurrency.
+// Throttle handles rate limiting using a token-bucket algorithm. Token-bucket
+// state is protected by a mutex: the previous lock-free implementation allowed
+// concurrent consumers to overdraw the bucket past zero, silently bypassing
+// the configured rate under contention.
 type Throttle struct {
 	rate     int64         // bytes per second (immutable after creation)
 	interval time.Duration // (immutable after creation)
-	lastTime atomic.Int64  // last check time in nanoseconds
-	tokens   atomic.Int64  // available tokens (bytes)
-	disabled atomic.Bool   // fast-path check
+	mu       sync.Mutex
+	lastTime atomic.Int64 // last check time in nanoseconds (atomic for test inspection)
+	tokens   atomic.Int64 // available tokens (bytes) (atomic for test inspection)
+	disabled atomic.Bool  // fast-path check
 	sleepFn  func(time.Duration)
 }
 
@@ -35,51 +39,34 @@ func NewThrottle(rate int64, interval time.Duration) *Throttle {
 }
 
 // Wait waits until enough tokens are available for the given bytes.
-// Uses a token bucket algorithm with atomic operations for lock-free rate limiting.
+// The mutex serialises bucket math so concurrent callers cannot both pass the
+// availability check and double-spend the same tokens.
 func (t *Throttle) Wait(bytes int64) {
 	// Fast path: throttling disabled
 	if t.disabled.Load() {
 		return
 	}
 
-	for {
-		now := time.Now().UnixNano()
-		last := t.lastTime.Load()
-		elapsed := now - last
+	t.mu.Lock()
+	now := time.Now().UnixNano()
+	last := t.lastTime.Load()
+	elapsed := now - last
 
-		// Calculate tokens to add based on elapsed time
-		tokensToAdd := (elapsed * t.rate) / int64(time.Second)
+	tokensToAdd := (elapsed * t.rate) / int64(time.Second)
+	t.lastTime.Store(now)
 
-		// Try to update the last time atomically
-		if !t.lastTime.CompareAndSwap(last, now) {
-			// Another goroutine updated it, retry
-			continue
-		}
+	current := min(t.tokens.Load()+tokensToAdd, t.rate)
 
-		// Add new tokens (capped at 1 second worth to prevent burst)
-		newTokens := t.tokens.Add(tokensToAdd)
-		if newTokens > t.rate {
-			t.tokens.Store(t.rate)
-			newTokens = t.rate
-		}
+	var waitNs int64
+	if current < bytes {
+		deficit := bytes - current
+		waitNs = (deficit * int64(time.Second)) / t.rate
+	}
 
-		// Try to consume tokens
-		if newTokens >= bytes {
-			t.tokens.Add(-bytes)
-			return
-		}
+	t.tokens.Store(current - bytes)
+	t.mu.Unlock()
 
-		// Not enough tokens, calculate wait time
-		deficit := bytes - newTokens
-		waitNs := (deficit * int64(time.Second)) / t.rate
-
-		if waitNs > 0 {
-			t.sleepFn(time.Duration(waitNs))
-		}
-
-		// After sleeping, consume the tokens
-		t.tokens.Add(-bytes)
-		t.lastTime.Store(time.Now().UnixNano())
-		return
+	if waitNs > 0 {
+		t.sleepFn(time.Duration(waitNs))
 	}
 }


### PR DESCRIPTION
## Summary

Defensive review of `internal/poster` surfaced four production-reachable crash and resource-leak paths. Each is fixed with a minimal local change; no behavioural changes on the happy path.

| Issue | Site | Symptom |
|---|---|---|
| Unguarded `checkQueue` send | [poster.go:642](internal/poster/poster.go) | postLoop deadlock + goroutine leak if checkLoop exits early |
| `rand.Intn(0)` on empty groups | [poster.go:993](internal/poster/poster.go) | panic when `GroupPolicy=each_file` and `cfg.Groups` is empty |
| Throttle bucket race | [throttle.go](internal/poster/throttle.go) | concurrent consumers overdraw past zero, silently bypassing rate |
| `ReadAt` hang on stalled mount | [poster.go:528](internal/poster/poster.go) | read-ahead goroutine + upload pipeline hang forever on dead NFS/FUSE/USB |

### Details

**checkQueue send guard** — `checkQueue` has a 100-slot buffer. If `checkLoop` returns from any of its error paths (verify failure, ctx cancel, pause error, max-retries-exhausted), nothing drains the buffer. After 100 more posts, `postLoop` blocked forever on the bare send. Now wrapped in a `select { case checkQueue <- post: case <-ctx.Done(): /* cleanup */ }`. On the cancel branch, the post is closed and its `postsInFlight` / `post.wg` counters are released so the closer goroutine can complete.

**Empty-groups guard** — Config validation may prevent empty `Groups`, but the poster did not enforce it locally. A misconfigured runtime now gets a typed error instead of a panic.

**Throttle correctness** — The previous CAS-based logic had two races: after a successful CAS, two goroutines could both pass `newTokens >= bytes` and both subtract (overdraw), and the post-sleep path always subtracted without re-checking. Replaced with a mutex-protected critical section. Atomic field types retained so existing tests compile unchanged.

**Read-ahead stall guard** — `*os.File.ReadAt` cannot be interrupted by context on regular files. New `readAtWithStallGuard` helper wraps it with a 60s wall-clock timeout. The OS-level goroutine still leaks until the kernel releases the syscall (fundamental Go limitation), but the upload pipeline gets a clean error and operators see a clear log line.

### Out of scope

Three items from the initial investigation report turned out, on closer review, **not** to be real bugs:
- `postsInFlight.Add(1)` ordering — the retry path Adds before Doneing the original, so the counter cannot transit zero between them.
- `errChan` buffer — sized 4 with max 3 outstanding writers, never fills.
- `postArticle` unbounded `make` — dead code; only `postArticleWithBody` is on the hot path.

These sites were inspected but not modified.

## Test plan

- [x] `go test -race -count=3 -timeout=180s ./internal/poster/...` — passes
- [x] `go vet ./internal/poster/...` — clean
- [x] `go build ./...` — clean
- [ ] Manual: post a folder under a throttled rate with `MaxConcurrentUploads > 1`, confirm observed throughput matches configured rate (regression test for H3)
- [ ] Manual: stop the verify server mid-upload, confirm postLoop exits instead of hanging (regression test for C3)