### PR TITLE
perf(dashboard): replace pause/jobs/pool polling with push events

### DIFF
--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -1,0 +1,21 @@
+// Push-event payload types for events emitted by the Go backend over WebSocket
+// (web mode) or the Wails runtime (desktop mode). These replace the polled
+// REST endpoints for pause state, running jobs, and NNTP pool metrics.
+
+import type { backend, processor } from "$lib/wailsjs/go/models";
+
+export interface ProcessingPauseEvent {
+	paused: boolean;
+	autoPaused: boolean;
+	reason: string;
+}
+
+export type RunningJobsEvent = processor.RunningJobDetails[];
+
+export type NntpPoolMetricsEvent = backend.NntpPoolMetrics;
+
+export const EVENT_PROCESSING_PAUSED = "processing:paused";
+export const EVENT_PROCESSING_RESUMED = "processing:resumed";
+export const EVENT_PROCESSING_AUTO_PAUSED = "processing:auto-paused";
+export const EVENT_RUNNING_JOBS_UPDATED = "running-jobs-updated";
+export const EVENT_NNTP_POOL_METRICS_UPDATED = "nntp-pool-metrics-updated";

--- a/frontend/src/lib/components/dashboard/DashboardHeader.svelte
+++ b/frontend/src/lib/components/dashboard/DashboardHeader.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
 import apiClient from "$lib/api/client";
+import {
+  EVENT_PROCESSING_AUTO_PAUSED,
+  EVENT_PROCESSING_PAUSED,
+  EVENT_PROCESSING_RESUMED,
+  type ProcessingPauseEvent,
+} from "$lib/api/events";
 import { t } from "$lib/i18n";
 import { toastStore } from "$lib/stores/toast";
 import { uploadActions, uploadStore } from "$lib/stores/upload";
@@ -17,40 +23,47 @@ let { needsConfiguration, criticalConfigError, handleUpload }: {
 let isPaused = $state(false);
 let isAutoPaused = $state(false);
 let autoPauseReason = $state("");
-let pauseCheckInterval: NodeJS.Timeout | null = null;
 let showFileExplorer = $state(false);
 let isWebMode = $state(false);
 
-// Check pause status and auto-pause status (only update if changed to prevent unnecessary re-renders)
-async function checkPauseStatus() {
-  try {
-    const newPaused = await apiClient.isProcessingPaused();
-    const newAutoPaused = await apiClient.isProcessingAutoPaused();
-    const newReason = await apiClient.getAutoPauseReason();
+function applyPauseEvent(data: unknown) {
+  const event = data as Partial<ProcessingPauseEvent> | undefined;
+  if (!event) return;
+  if (typeof event.paused === "boolean") isPaused = event.paused;
+  if (typeof event.autoPaused === "boolean") isAutoPaused = event.autoPaused;
+  if (typeof event.reason === "string") autoPauseReason = event.reason;
+}
 
-    if (isPaused !== newPaused) isPaused = newPaused;
-    if (isAutoPaused !== newAutoPaused) isAutoPaused = newAutoPaused;
-    if (autoPauseReason !== newReason) autoPauseReason = newReason;
+async function fetchInitialPauseStatus() {
+  try {
+    const [paused, autoPaused, reason] = await Promise.all([
+      apiClient.isProcessingPaused(),
+      apiClient.isProcessingAutoPaused(),
+      apiClient.getAutoPauseReason(),
+    ]);
+    isPaused = paused;
+    isAutoPaused = autoPaused;
+    autoPauseReason = reason;
   } catch (error) {
-    console.error("Failed to check pause status:", error);
+    console.error("Failed to fetch initial pause status:", error);
   }
 }
 
-// Check environment and setup periodic pause status checks
 onMount(async () => {
-  checkPauseStatus();
-  pauseCheckInterval = setInterval(checkPauseStatus, 1000);
-  
-  // Check if we're in web mode
   await apiClient.initialize();
   isWebMode = apiClient.environment === "web";
+
+  await fetchInitialPauseStatus();
+
+  await apiClient.on(EVENT_PROCESSING_PAUSED, applyPauseEvent);
+  await apiClient.on(EVENT_PROCESSING_RESUMED, applyPauseEvent);
+  await apiClient.on(EVENT_PROCESSING_AUTO_PAUSED, applyPauseEvent);
 });
 
 onDestroy(() => {
-  if (pauseCheckInterval) {
-    clearInterval(pauseCheckInterval);
-    pauseCheckInterval = null;
-  }
+  apiClient.off(EVENT_PROCESSING_PAUSED, applyPauseEvent);
+  apiClient.off(EVENT_PROCESSING_RESUMED, applyPauseEvent);
+  apiClient.off(EVENT_PROCESSING_AUTO_PAUSED, applyPauseEvent);
 });
 
 function formatFileSize(bytes: number): string {

--- a/frontend/src/lib/components/dashboard/ProgressSection.svelte
+++ b/frontend/src/lib/components/dashboard/ProgressSection.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
 import apiClient from "$lib/api/client";
+import {
+  EVENT_PROCESSING_AUTO_PAUSED,
+  EVENT_PROCESSING_PAUSED,
+  EVENT_PROCESSING_RESUMED,
+  EVENT_RUNNING_JOBS_UPDATED,
+  type ProcessingPauseEvent,
+  type RunningJobsEvent,
+} from "$lib/api/events";
 import { t } from "$lib/i18n";
 import { isUploading, runningJobs } from "$lib/stores/app";
 import { toastStore } from "$lib/stores/toast";
@@ -7,61 +15,51 @@ import { formatSpeed, formatTime, formatFileSize } from "$lib/utils";
 import { ChartPie, CheckCircle, Play, X, Upload, Package, Check } from "lucide-svelte";
 import { onMount, onDestroy } from "svelte";
 
-// Use the generated types from Wails
-let progressUpdateInterval: NodeJS.Timeout | null = null;
 let isPaused = $state(false);
 let destroyed = false;
 
-// Fetch progress data from API
-async function fetchProgressData() {
+function applyRunningJobs(data: unknown) {
+  if (destroyed) return;
+  const jobs = (data ?? []) as RunningJobsEvent;
+  runningJobs.set(jobs);
+}
+
+function applyPauseEvent(data: unknown) {
+  const event = data as Partial<ProcessingPauseEvent> | undefined;
+  if (event && typeof event.paused === "boolean") {
+    isPaused = event.paused;
+  }
+}
+
+async function fetchInitialState() {
   try {
-    const [jobDetails, pausedStatus] = await Promise.all([
+    const [jobs, paused] = await Promise.all([
       apiClient.getRunningJobDetails(),
-      apiClient.isProcessingPaused()
+      apiClient.isProcessingPaused(),
     ]);
     if (destroyed) return;
-    runningJobs.set(jobDetails);
-    isPaused = pausedStatus;
+    runningJobs.set(jobs);
+    isPaused = paused;
   } catch (error) {
-    console.error("Failed to fetch progress data:", error);
+    console.error("Failed to fetch initial progress state:", error);
   }
 }
 
-function startPolling() {
-  if (progressUpdateInterval) return;
-  progressUpdateInterval = setInterval(fetchProgressData, 500);
-}
+onMount(async () => {
+  await fetchInitialState();
 
-function stopPolling() {
-  if (progressUpdateInterval) {
-    clearInterval(progressUpdateInterval);
-    progressUpdateInterval = null;
-  }
-}
-
-function handleVisibilityChange() {
-  if (document.hidden) {
-    stopPolling();
-  } else {
-    fetchProgressData();
-    startPolling();
-  }
-}
-
-// Setup periodic progress updates
-onMount(() => {
-  // Initial fetch
-  fetchProgressData();
-
-  // Update every 500ms for real-time progress (pauses when tab inactive)
-  startPolling();
-  document.addEventListener("visibilitychange", handleVisibilityChange);
+  await apiClient.on(EVENT_RUNNING_JOBS_UPDATED, applyRunningJobs);
+  await apiClient.on(EVENT_PROCESSING_PAUSED, applyPauseEvent);
+  await apiClient.on(EVENT_PROCESSING_RESUMED, applyPauseEvent);
+  await apiClient.on(EVENT_PROCESSING_AUTO_PAUSED, applyPauseEvent);
 });
 
 onDestroy(() => {
   destroyed = true;
-  stopPolling();
-  document.removeEventListener("visibilitychange", handleVisibilityChange);
+  apiClient.off(EVENT_RUNNING_JOBS_UPDATED, applyRunningJobs);
+  apiClient.off(EVENT_PROCESSING_PAUSED, applyPauseEvent);
+  apiClient.off(EVENT_PROCESSING_RESUMED, applyPauseEvent);
+  apiClient.off(EVENT_PROCESSING_AUTO_PAUSED, applyPauseEvent);
 });
 
 // Function to get icon for progress type

--- a/frontend/src/lib/components/dashboard/ProviderStatus.svelte
+++ b/frontend/src/lib/components/dashboard/ProviderStatus.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 import apiClient from "$lib/api/client";
+import {
+	EVENT_NNTP_POOL_METRICS_UPDATED,
+	type NntpPoolMetricsEvent,
+} from "$lib/api/events";
 import { t } from "$lib/i18n";
 import { backend } from "$lib/wailsjs/go/models";
 import { CheckCircle, Clock, AlertCircle, Server, WifiOff } from "lucide-svelte";
@@ -9,10 +13,12 @@ import { onDestroy, onMount } from "svelte";
 let poolMetrics = $state<backend.NntpPoolMetrics | null>(null);
 let initialLoad = $state(true);
 let error = $state("");
-let refreshInterval: NodeJS.Timeout | null = null;
 
-// Refresh every 5 seconds
-const REFRESH_INTERVAL = 5000;
+function applyPoolMetrics(data: unknown) {
+	if (!data) return;
+	poolMetrics = data as NntpPoolMetricsEvent;
+	error = "";
+}
 
 async function fetchProviderStatus() {
 	try {
@@ -70,38 +76,13 @@ function formatSpeed(bytesPerSec: number): string {
 	return formatBytes(bytesPerSec) + "/s";
 }
 
-function startPolling() {
-	if (refreshInterval) return;
-	refreshInterval = setInterval(fetchProviderStatus, REFRESH_INTERVAL);
-}
-
-function stopPolling() {
-	if (refreshInterval) {
-		clearInterval(refreshInterval);
-		refreshInterval = null;
-	}
-}
-
-function handleVisibilityChange() {
-	if (document.hidden) {
-		stopPolling();
-	} else {
-		fetchProviderStatus();
-		startPolling();
-	}
-}
-
-onMount(() => {
-	fetchProviderStatus();
-
-	// Set up auto-refresh (pauses when tab inactive)
-	startPolling();
-	document.addEventListener("visibilitychange", handleVisibilityChange);
+onMount(async () => {
+	await fetchProviderStatus();
+	await apiClient.on(EVENT_NNTP_POOL_METRICS_UPDATED, applyPoolMetrics);
 });
 
 onDestroy(() => {
-	stopPolling();
-	document.removeEventListener("visibilitychange", handleVisibilityChange);
+	apiClient.off(EVENT_NNTP_POOL_METRICS_UPDATED, applyPoolMetrics);
 });
 </script>
 

--- a/frontend/src/routes/metrics/+page.svelte
+++ b/frontend/src/routes/metrics/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 import apiClient from "$lib/api/client";
+import {
+	EVENT_NNTP_POOL_METRICS_UPDATED,
+	type NntpPoolMetricsEvent,
+} from "$lib/api/events";
 import { t } from "$lib/i18n";
 import { toastStore } from "$lib/stores/toast";
 import { onMount, onDestroy } from "svelte";
@@ -10,31 +14,20 @@ import { formatElapsed } from "$lib/utils";
 let metrics = $state<backend.NntpPoolMetrics | null>(null);
 let loading = $state(true);
 let error = $state<string | null>(null);
-let refreshInterval = $state<NodeJS.Timeout | null>(null);
-
-// Auto-refresh every 5 seconds
-const REFRESH_INTERVAL = 5000;
 
 onMount(async () => {
 	await loadMetrics();
-	startAutoRefresh();
+	await apiClient.on(EVENT_NNTP_POOL_METRICS_UPDATED, applyMetricsEvent);
 });
 
 onDestroy(() => {
-	stopAutoRefresh();
+	apiClient.off(EVENT_NNTP_POOL_METRICS_UPDATED, applyMetricsEvent);
 });
 
-function startAutoRefresh() {
-	refreshInterval = setInterval(async () => {
-		await loadMetrics(false); // Don't show loading state on auto-refresh
-	}, REFRESH_INTERVAL);
-}
-
-function stopAutoRefresh() {
-	if (refreshInterval) {
-		clearInterval(refreshInterval);
-		refreshInterval = null;
-	}
+function applyMetricsEvent(data: unknown) {
+	if (!data) return;
+	metrics = data as NntpPoolMetricsEvent;
+	error = null;
 }
 
 async function loadMetrics(showLoading = true) {
@@ -85,7 +78,7 @@ function formatNumber(num: number): string {
 		<div class="flex items-center gap-3">
 			<!-- Auto-refresh indicator -->
 			<div class="flex items-center gap-2 text-sm text-base-content/60">
-				<Activity class="w-4 h-4 {refreshInterval ? 'animate-pulse text-primary' : ''}" />
+				<Activity class="w-4 h-4 animate-pulse text-primary" />
 				<span>{$t('metrics.auto_refresh')}</span>
 			</div>
 

--- a/internal/backend/app.go
+++ b/internal/backend/app.go
@@ -122,6 +122,7 @@ type App struct {
 	pendingConfigMux     sync.RWMutex
 	isApplyingConfig     atomic.Bool
 	postCheckWorker      *processor.PostCheckRetryWorker
+	broadcaster          *eventBroadcaster
 }
 
 // getCrashLogPath returns the path for crash logs
@@ -390,6 +391,10 @@ func (a *App) Startup(ctx context.Context) {
 		}
 	}
 
+	// Start the event broadcaster. It runs in both web and desktop modes and
+	// drives push events that replace per-client polling.
+	a.broadcaster = newEventBroadcaster(a)
+	a.broadcaster.start()
 }
 
 // Shutdown gracefully shuts down the application and closes all resources
@@ -397,6 +402,12 @@ func (a *App) Shutdown() {
 	defer a.recoverPanic("Shutdown")
 
 	slog.Info("Application shutdown initiated")
+
+	// Stop the event broadcaster before tearing down the components it reads from.
+	if a.broadcaster != nil {
+		a.broadcaster.stop()
+		a.broadcaster = nil
+	}
 
 	// Stop post check retry worker if running
 	if a.postCheckWorker != nil {
@@ -982,6 +993,37 @@ func (a *App) TestProviderConnectivity(serverData ServerData) ValidationResult {
 	}
 }
 
+// ProcessingPauseState is the payload broadcast with pause-related events. A
+// full snapshot lets the UI render the header without follow-up RPCs.
+type ProcessingPauseState struct {
+	Paused     bool   `json:"paused"`
+	AutoPaused bool   `json:"autoPaused"`
+	Reason     string `json:"reason"`
+}
+
+// pauseState returns a snapshot of the current pause/auto-pause state.
+func (a *App) pauseState() ProcessingPauseState {
+	return ProcessingPauseState{
+		Paused:     a.IsProcessingPaused(),
+		AutoPaused: a.IsProcessingAutoPaused(),
+		Reason:     a.GetAutoPauseReason(),
+	}
+}
+
+// emit dispatches an event through the active transport (Wails runtime in
+// desktop mode, the WebSocket hub in web mode).
+func (a *App) emit(eventType string, payload any) {
+	if a.isWebMode {
+		if a.webEventEmitter != nil {
+			a.webEventEmitter(eventType, payload)
+		}
+		return
+	}
+	if a.ctx != nil {
+		wailsruntime.EventsEmit(a.ctx, eventType, payload)
+	}
+}
+
 // PauseProcessing pauses the processor to prevent new jobs from starting
 func (a *App) PauseProcessing() error {
 	defer a.recoverPanic("PauseProcessing")
@@ -993,12 +1035,7 @@ func (a *App) PauseProcessing() error {
 	a.processor.PauseProcessing()
 	slog.Info("Processing paused via API")
 
-	// Emit events for both desktop and web modes
-	if !a.isWebMode {
-		wailsruntime.EventsEmit(a.ctx, "processing:paused")
-	} else if a.webEventEmitter != nil {
-		a.webEventEmitter("processing:paused", nil)
-	}
+	a.emit("processing:paused", a.pauseState())
 
 	return nil
 }
@@ -1014,12 +1051,7 @@ func (a *App) ResumeProcessing() error {
 	a.processor.ResumeProcessing()
 	slog.Info("Processing resumed via API")
 
-	// Emit events for both desktop and web modes
-	if !a.isWebMode {
-		wailsruntime.EventsEmit(a.ctx, "processing:resumed")
-	} else if a.webEventEmitter != nil {
-		a.webEventEmitter("processing:resumed", nil)
-	}
+	a.emit("processing:resumed", a.pauseState())
 
 	return nil
 }

--- a/internal/backend/broadcaster.go
+++ b/internal/backend/broadcaster.go
@@ -1,0 +1,127 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	runningJobsTickInterval = 1 * time.Second
+	nntpMetricsTickInterval = 5 * time.Second
+)
+
+// eventBroadcaster periodically snapshots app state and emits change events to
+// connected UIs (Wails runtime in desktop mode, WebSocket hub in web mode).
+// One shared ticker per metric replaces what was previously per-client polling.
+type eventBroadcaster struct {
+	app    *App
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func newEventBroadcaster(app *App) *eventBroadcaster {
+	return &eventBroadcaster{app: app}
+}
+
+// start launches the broadcast loops. Safe to call once; subsequent calls are
+// no-ops while a previous start is still active.
+func (b *eventBroadcaster) start() {
+	if b.cancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	b.cancel = cancel
+
+	b.wg.Add(2)
+	go b.runRunningJobsLoop(ctx)
+	go b.runPoolMetricsLoop(ctx)
+}
+
+// stop cancels all broadcast loops and waits for them to exit.
+func (b *eventBroadcaster) stop() {
+	if b.cancel == nil {
+		return
+	}
+	b.cancel()
+	b.wg.Wait()
+	b.cancel = nil
+}
+
+// runRunningJobsLoop emits running-jobs-updated when the snapshot changes, and
+// piggybacks auto-pause state-change detection on the same tick.
+func (b *eventBroadcaster) runRunningJobsLoop(ctx context.Context) {
+	defer b.wg.Done()
+	ticker := time.NewTicker(runningJobsTickInterval)
+	defer ticker.Stop()
+
+	var lastJobsJSON []byte
+	var lastPauseJSON []byte
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.tickRunningJobs(&lastJobsJSON)
+			b.tickAutoPause(&lastPauseJSON)
+		}
+	}
+}
+
+func (b *eventBroadcaster) tickRunningJobs(lastJSON *[]byte) {
+	jobs, err := b.app.GetRunningJobsDetails()
+	if err != nil {
+		slog.Debug("broadcaster: failed to read running jobs", "error", err)
+		return
+	}
+	payload, err := json.Marshal(jobs)
+	if err != nil {
+		slog.Debug("broadcaster: failed to marshal running jobs", "error", err)
+		return
+	}
+	if bytes.Equal(payload, *lastJSON) {
+		return
+	}
+	*lastJSON = payload
+	b.app.emit("running-jobs-updated", jobs)
+}
+
+func (b *eventBroadcaster) tickAutoPause(lastJSON *[]byte) {
+	state := b.app.pauseState()
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	if bytes.Equal(payload, *lastJSON) {
+		return
+	}
+	*lastJSON = payload
+	b.app.emit("processing:auto-paused", state)
+}
+
+// runPoolMetricsLoop emits NNTP pool metrics on a fixed cadence. We do not
+// dedupe because timestamp/elapsed/avg-speed drift every tick, and a 5s
+// cadence is cheap enough.
+func (b *eventBroadcaster) runPoolMetricsLoop(ctx context.Context) {
+	defer b.wg.Done()
+	ticker := time.NewTicker(nntpMetricsTickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			metrics, err := b.app.GetNntpPoolMetrics()
+			if err != nil {
+				slog.Debug("broadcaster: failed to read pool metrics", "error", err)
+				continue
+			}
+			b.app.emit("nntp-pool-metrics-updated", metrics)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three dashboard endpoints were polled by every client on tight intervals:

| Endpoint | Poll | Caller |
|---|---|---|
| `/api/processor/paused` (+ auto-paused, reason) | 1000 ms | `DashboardHeader.svelte` |
| `/api/running-job-details` | **500 ms** | `ProgressSection.svelte` |
| `/api/metrics/nntp-pool` | 5000 ms | `ProviderStatus.svelte`, `routes/metrics/+page.svelte` |

That's ~3 req/s per idle client. It also caused the "HTML instead of JSON" symptom in dev: when the Go backend on `:8080` was unreachable, the Vite proxy returned the SPA `index.html`, which crashed `JSON.parse` in `web-client.ts`.

This PR replaces the polling with push events over the existing WebSocket hub. **No new transport** — SSE was considered and rejected in favor of reusing the WS infrastructure already used for upload/config events.

## What changed

**Backend (`internal/backend/`)**
- `app.go` — added a `ProcessingPauseState` payload and `pauseState()` helper; added `App.emit(event, payload)` that routes to Wails runtime (desktop) or `webEventEmitter` (web). `PauseProcessing`/`ResumeProcessing` now broadcast the full pause snapshot so the UI doesn't need follow-up RPCs.
- `broadcaster.go` *(new)* — one shared ticker per metric:
  - 1 s → `running-jobs-updated` (JSON dedupe; idle state goes silent)
  - 1 s → `processing:auto-paused` (state-change detection only)
  - 5 s → `nntp-pool-metrics-updated`
  - Wired into `Startup` / `Shutdown`.

**Frontend**
- `lib/api/events.ts` *(new)* — typed event payloads + event-name constants.
- `DashboardHeader.svelte`, `ProgressSection.svelte`, `ProviderStatus.svelte`, `routes/metrics/+page.svelte` — drop `setInterval` loops and visibility-change handlers, fetch once on mount, then subscribe via `apiClient.on()`.

## Net effect

Replaces **N pollers × per-client** with **1 ticker × server-side**. A typical idle dashboard goes from ~3 req/s to **zero** recurring HTTP traffic; updates arrive as WS frames.

## Reviewer notes

- The REST endpoints stay — they're still used for the initial fetch on mount. Removing them would force a "wait for first event" race on every page load.
- `nntp-pool-metrics-updated` is *not* deduped because `Timestamp` / `Elapsed` / `AvgSpeed` drift every tick; the cost of an unconditional 5 s emit is negligible.
- `running-jobs-updated` dedupe is most effective when idle (no jobs → identical empty payload → no emit).
- Auto-pause emission piggybacks on the running-jobs tick rather than instrumenting `internal/processor/` to avoid an import cycle into `internal/backend/`.

## Test plan

- [x] `go build ./internal/... ./cmd/web/...`
- [x] `go vet ./internal/... ./cmd/web/...`
- [x] `go test -race ./internal/processor/... ./internal/queue/...`
- [x] `bun run check` — 0 errors, 0 warnings
- [ ] Manual: `go run ./cmd/web` + `bun run dev`, confirm DevTools shows each of the three endpoints called **once** on mount and never again; WS frames carry the new event types.
- [ ] Manual: toggle pause from the dashboard, confirm header updates with no network round-trip.
- [ ] Manual: kill backend then restart, confirm WS reconnect resyncs dashboard state.
- [ ] Manual: same flow in Wails desktop (`wails dev`).