### PR TITLE
fix(par2): SIMD-align slice size to prevent random AVX-512 segfaults

### DIFF
--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -261,9 +261,9 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		}
 	}
 	parBlockSize := p.computeSetBlockSize(totalSize, maxFileSize)
-	if parBlockSize < 4 {
-		slog.WarnContext(ctx, "Block size too small for PAR2 set creation, skipping",
-			"setName", setName, "totalSize", totalSize)
+	if parBlockSize < 128 {
+		slog.WarnContext(ctx, "Block size too small for SIMD-safe PAR2 set creation, skipping",
+			"setName", setName, "totalSize", totalSize, "blockSize", parBlockSize)
 		return nil, nil
 	}
 
@@ -369,14 +369,18 @@ func (p *NativeExecutor) computeSetBlockSize(totalSize, maxFileSize uint64) uint
 		}
 	}
 	// SIMD-safe alignment when a single file is smaller than the block size.
+	const simdSafeAlignment = uint64(128)
 	if maxFileSize > 0 && parBlockSize > maxFileSize {
-		const simdSafeAlignment = uint64(128)
 		if maxFileSize < simdSafeAlignment {
 			return 0
 		}
 		parBlockSize = (maxFileSize / simdSafeAlignment) * simdSafeAlignment
 	}
-	return alignDown(parBlockSize, 4)
+	// Every slice size handed to par2go must be SIMD-aligned. The ParPar C
+	// backend reads in vector lanes up to 64 bytes wide; a non-aligned size
+	// causes overreads past the slice buffer and intermittent segfaults on
+	// Linux x86_64 / AVX-512. 128 covers all current strides.
+	return alignDown(parBlockSize, simdSafeAlignment)
 }
 
 // checkExistingPar2SetInPath looks for an already-generated par2 set in
@@ -413,39 +417,44 @@ func collectPar2SetFiles(ctx context.Context, dirPath, setName, mainPath string)
 	return out
 }
 
-// createPar2ForFile creates PAR2 files for a single input file in the given directory.
-func (p *NativeExecutor) createPar2ForFile(ctx context.Context, file fileinfo.FileInfo, dirPath string) ([]string, error) {
+// computeFileBlockSize picks a SIMD-safe slice size for a single file. Returns
+// 0 when no safe block size exists (file smaller than the SIMD alignment).
+// Exposed at package level so tests can assert the invariant directly.
+func computeFileBlockSize(fileSize, articleSize uint64, configuredSliceSize int64) uint64 {
+	const simdSafeAlignment = uint64(128)
+
 	var parBlockSize uint64
-	if p.cfg.SliceSize > 0 && uint64(p.cfg.SliceSize) <= file.Size {
-		parBlockSize = uint64(p.cfg.SliceSize)
+	if configuredSliceSize > 0 && uint64(configuredSliceSize) <= fileSize {
+		parBlockSize = uint64(configuredSliceSize)
 	} else {
 		// Configured SliceSize exceeds file size (or is unset): fall back to
 		// article-size-based calculation. Clamping SliceSize to ≈file.Size
 		// creates only 1-2 slices with a nearly-zero last slice, which triggers
 		// undefined behavior in the ParPar C SIMD backend on Linux x86_64 (AVX-512).
-		parBlockSize = calculateParBlockSize(file.Size, p.articleSize)
+		parBlockSize = calculateParBlockSize(fileSize, articleSize)
 	}
-	// Guard: block size must not exceed file size AND must be SIMD-aligned.
-	// The underlying ParPar C library may read up to (stride-1) bytes past the buffer
-	// end when sliceSize is not a multiple of the SIMD stride (e.g. 64 bytes for
-	// AVX-512 on Linux x86_64). Round DOWN to nearest 128-byte boundary after
-	// clamping to prevent buffer overreads and segfaults.
-	if file.Size > 0 && parBlockSize > file.Size {
-		const simdSafeAlignment = uint64(128)
-		if file.Size < simdSafeAlignment {
-			// File smaller than SIMD-safe alignment — par2go's C backend may read
-			// past the buffer end with sub-stride slice sizes, causing a segfault
-			// on AVX-512 hardware. Skip PAR2 creation for such tiny files.
-			slog.WarnContext(ctx, "File too small for SIMD-safe PAR2 creation, skipping",
-				"path", file.Path, "size", file.Size)
-			return nil, nil
+	if fileSize > 0 && parBlockSize > fileSize {
+		if fileSize < simdSafeAlignment {
+			return 0
 		}
-		parBlockSize = (file.Size / simdSafeAlignment) * simdSafeAlignment
+		parBlockSize = (fileSize / simdSafeAlignment) * simdSafeAlignment
 	}
-	// PAR2 spec requires slice size to be a multiple of 4
-	parBlockSize = alignDown(parBlockSize, 4)
-	if parBlockSize < 4 {
-		slog.WarnContext(ctx, "Block size too small for PAR2 creation, skipping",
+	parBlockSize = alignDown(parBlockSize, simdSafeAlignment)
+	if parBlockSize < simdSafeAlignment {
+		return 0
+	}
+	return parBlockSize
+}
+
+// createPar2ForFile creates PAR2 files for a single input file in the given directory.
+func (p *NativeExecutor) createPar2ForFile(ctx context.Context, file fileinfo.FileInfo, dirPath string) ([]string, error) {
+	// Slice size handed to par2go MUST be a multiple of 128 (SIMD-safe). Otherwise
+	// the ParPar C backend overreads past the slice on the last vector lane and
+	// randomly segfaults when the over-read crosses an unmapped page (AVX-512 on
+	// Linux x86_64). See computeFileBlockSize for the alignment policy.
+	parBlockSize := computeFileBlockSize(file.Size, p.articleSize, p.cfg.SliceSize)
+	if parBlockSize == 0 {
+		slog.WarnContext(ctx, "Block size too small for SIMD-safe PAR2 creation, skipping",
 			"path", file.Path, "size", file.Size)
 		return nil, nil
 	}

--- a/internal/par2/par2_test.go
+++ b/internal/par2/par2_test.go
@@ -207,6 +207,49 @@ func TestIsPar2File(t *testing.T) {
 	}
 }
 
+// TestComputeFileBlockSize_SIMDAligned is a regression test for the random
+// segfault in CI (run 26437870974). The previous code path produced a
+// 10_000-byte slice size for {articleSize=10_000, file=100 KB, SliceSize=10 MiB},
+// which is not a multiple of the AVX-512 stride (64 bytes) and caused the
+// ParPar C backend to overread past the slice buffer.
+func TestComputeFileBlockSize_SIMDAligned(t *testing.T) {
+	const simdAlignment = uint64(128)
+	cases := []struct {
+		name                string
+		fileSize            uint64
+		articleSize         uint64
+		configuredSliceSize int64
+		wantZero            bool
+	}{
+		{"CI repro: 100KB file, 10K article, 10MiB cfg", 100_000, 10_000, 10 * 1024 * 1024, false},
+		{"100KB file, default article (750K), no cfg", 100_000, 750_000, 0, false},
+		{"10MB file, 512K article", 10 * 1024 * 1024, 512 * 1024, 0, false},
+		{"127-byte file too small", 127, 750_000, 0, true},
+		{"128-byte file is minimum", 128, 750_000, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeFileBlockSize(tc.fileSize, tc.articleSize, tc.configuredSliceSize)
+			if tc.wantZero {
+				if got != 0 {
+					t.Errorf("expected 0 (skip), got %d", got)
+				}
+				return
+			}
+			if got == 0 {
+				t.Fatal("expected non-zero block size, got 0")
+			}
+			if got%simdAlignment != 0 {
+				t.Errorf("block size %d is not a multiple of %d — would crash ParPar SIMD backend", got, simdAlignment)
+			}
+			if got > tc.fileSize {
+				t.Errorf("block size %d exceeds file size %d", got, tc.fileSize)
+			}
+		})
+	}
+}
+
 func TestCalculateParBlockSize(t *testing.T) {
 	testCases := []struct {
 		fileSize    uint64


### PR DESCRIPTION
## Summary

Fixes the random `signal: segmentation fault (core dumped)` in the `Coverage` workflow
on `internal/par2` (e.g. [run 26437870974 / job 77824805140](https://github.com/javi11/postie/actions/runs/26437870974/job/77824805140?pr=230)).

## Root cause

`createPar2ForFile` only rounded the slice size to a 4-byte boundary (per the PAR2 spec)
before handing it to `par2go`. The ParPar C kernel on Linux x86_64 with AVX-512 reads in
64-byte vector lanes, so a non-aligned slice size (e.g. `articleSize = 10_000` →
`SliceSize = 10_000`, which is `156 * 64 + 16`) causes overreads past the slice buffer.

The crash only fires when the over-read happens to cross an unmapped page. That depends
on the allocator's run-to-run layout — flaky on Linux CI, never reproducible locally on
macOS / arm64 (different SIMD stride, and the existing 128-byte clamp happened to mask it).

The source already documented the requirement at `par2.go:430-444`, but the SIMD-safe
alignment guard was only applied when `parBlockSize > file.Size`. For the failing path
(`SliceSize = 10MiB > file.Size = 100KB → fallback → articleSize = 10_000`) the guard
was skipped entirely.

## Fix

- Extract per-file block-size policy into a testable `computeFileBlockSize` helper.
- Make 128-byte SIMD alignment **unconditional** for every slice size handed to `par2go`
  (both `createPar2ForFile` and `computeSetBlockSize`).
- Raise the "block too small" threshold from `4` to `128` and emit a clear "SIMD-safe"
  warning when skipping.
- Add `TestComputeFileBlockSize_SIMDAligned` covering the CI repro case plus several
  edge cases; asserts `result % 128 == 0` so we can't regress silently.

## Test plan

- [x] `go build ./internal/par2/...`
- [x] `go test -race -count=3 ./internal/par2/...` — passes
- [x] `TestComputeFileBlockSize_SIMDAligned` covers the previously-crashing parameters
- [ ] CI Coverage workflow goes green on Linux x86_64