### PR TITLE
ci: verify Windows CLI has no MinGW runtime DLL dependencies

### DIFF
--- a/.github/actions/verify-windows-gui-dlls/action.yml
+++ b/.github/actions/verify-windows-gui-dlls/action.yml
@@ -1,8 +1,8 @@
-name: Verify Windows GUI DLL dependencies
-description: Fails if the built Windows GUI exe imports MinGW runtime DLLs (libgcc_s_seh-1.dll, libstdc++-6.dll, libwinpthread-1.dll).
+name: Verify Windows DLL dependencies
+description: Fails if the built Windows exe imports MinGW runtime DLLs (libgcc_s_seh-1.dll, libstdc++-6.dll, libwinpthread-1.dll).
 inputs:
   exe-glob:
-    description: Glob for the built GUI exe
+    description: Glob for the built exe
     required: false
     default: build/bin/*.exe
 runs:
@@ -24,7 +24,7 @@ runs:
         echo "-------------------"
         forbidden='libgcc_s_seh-1\.dll|libstdc\+\+-6\.dll|libwinpthread-1\.dll'
         if echo "$imports" | grep -iE "$forbidden"; then
-          echo "::error::Windows GUI exe depends on MinGW runtime DLL(s); static linking regressed."
+          echo "::error::Windows exe depends on MinGW runtime DLL(s); static linking regressed."
           exit 1
         fi
         echo "OK: no MinGW runtime DLL dependencies found."

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -186,6 +186,11 @@ jobs:
             -o "postie-cli-windows-amd64.exe" \
             ./cmd/postie/postie.go
 
+      - name: Verify no MinGW runtime DLL dependencies
+        uses: ./.github/actions/verify-windows-gui-dlls
+        with:
+          exe-glob: postie-cli-windows-amd64.exe
+
       - name: Upload Windows CLI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,13 @@ jobs:
             -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}" \
             ./cmd/postie/postie.go
 
+      # Catch static-linking regressions in CI instead of at user launch time
+      - name: Verify no MinGW runtime DLL dependencies
+        if: matrix.goos == 'windows'
+        uses: ./.github/actions/verify-windows-gui-dlls
+        with:
+          exe-glob: postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}.exe
+
       # Create archive
       - name: Create archive
         run: |


### PR DESCRIPTION
## What

Adds the "Verify no MinGW runtime DLL dependencies" check (objdump PE-import scan for `libgcc_s_seh-1.dll`, `libstdc++-6.dll`, `libwinpthread-1.dll`) to the Windows **CLI** build jobs:

- `dev-build.yml` → `build-cli-windows` job, right after the build and before the artifact upload
- `release.yml` → `build-cli` matrix job, gated on `matrix.goos == 'windows'`, before archiving
- Generalizes the composite action's GUI-specific wording (`verify-windows-gui-dlls`) since it now covers both GUI and CLI exes; logic unchanged

## Why

In #198, users had to place the three MinGW runtime DLLs next to `postie-cli-windows-amd64.exe` because static linking had silently regressed (MSYS2's rolling repo moved to GCC 16, later pinned in #234). The GUI job already had a CI guard against this (#206), but the CLI job did not — so the regression shipped and was only discovered by users at launch time. This closes that gap.

## Reviewer notes

- Both CLI jobs already set up MSYS2, which the composite action needs (`shell: msys2 {0}` for `objdump`), so no extra setup steps were required.
- `actionlint` passes on both workflows.
- Verification: the `build-cli-windows` job on this PR's dev build should pass the new step; to see it fail, drop the `-extldflags '-static'` flags locally.