### PR TITLE
fix(ci): build Windows CLI in MSYS2 shell so static linking applies

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -2,9 +2,7 @@ name: Dev Build
 
 on:
   push:
-    # TEMP: fix/ci-windows-cli-static-link added to verify the CLI static-link
-    # fix before merge — remove before merging.
-    branches: [main, fix/ci-windows-cli-static-link]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -2,7 +2,9 @@ name: Dev Build
 
 on:
   push:
-    branches: [main]
+    # TEMP: fix/ci-windows-cli-static-link added to verify the CLI static-link
+    # fix before merge — remove before merging.
+    branches: [main, fix/ci-windows-cli-static-link]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -154,6 +156,7 @@ jobs:
           msystem: MINGW64
           install: ''
           update: false
+          path-type: inherit
 
       # Pin the MinGW GCC toolchain (see build-gui-windows for rationale).
       - name: Pin MinGW GCC toolchain
@@ -171,13 +174,17 @@ jobs:
           COMMIT=$(git rev-parse --short HEAD)
           echo "version=dev-$COMMIT" >> $GITHUB_OUTPUT
 
+      # Build inside the MSYS2 shell so the pinned MSYS2 GCC (not the runner's
+      # pre-installed MinGW) does the cgo link — its static libs make
+      # -extldflags '-static' fully effective (same recipe as build-gui-windows).
       - name: Build Windows CLI
+        shell: msys2 {0}
         env:
           GOOS: windows
           GOARCH: amd64
           CGO_ENABLED: 1
           CC: gcc
-          CGO_LDFLAGS: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
+          CGO_LDFLAGS: '-static-libgcc -static-libstdc++'
         run: |
           go build \
             -trimpath \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
             goarch: amd64
             runner: windows-latest
             cc: gcc
-            cgo_ldflags: '-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic'
+            cgo_ldflags: '-static-libgcc -static-libstdc++'
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -131,6 +131,7 @@ jobs:
           msystem: MINGW64
           install: ''
           update: false
+          path-type: inherit
 
       # Pin the MinGW GCC toolchain. MSYS2 is a rolling repo; GCC 16 dropped the
       # emulated-TLS std::call_once symbols the prebuilt par2go
@@ -166,6 +167,7 @@ jobs:
 
       # Build binary
       - name: Build ${{ matrix.goos }}-${{ matrix.goarch }} binary
+        if: matrix.goos != 'windows'
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -173,24 +175,31 @@ jobs:
           CC: ${{ matrix.cc }}
           CGO_LDFLAGS: ${{ matrix.cgo_ldflags }}
         run: |
-          # Set binary extension for Windows
-          EXT=""
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            EXT=".exe"
-          fi
-
-          # Set extra ldflags for static linking on Windows
-          EXTRA_LDFLAGS=""
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            EXTRA_LDFLAGS="-linkmode external -extldflags '-static'"
-          fi
-
-          # Build the binary
           go build \
             -trimpath \
             -tags=cli \
-            -ldflags="-s -w ${EXTRA_LDFLAGS} -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
-            -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}" \
+            -ldflags="-s -w -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
+            -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}" \
+            ./cmd/postie/postie.go
+
+      # Build inside the MSYS2 shell so the pinned MSYS2 GCC (not the runner's
+      # pre-installed MinGW) does the cgo link — its static libs make
+      # -extldflags '-static' fully effective (same recipe as build-gui-windows).
+      - name: Build ${{ matrix.goos }}-${{ matrix.goarch }} binary (Windows)
+        if: matrix.goos == 'windows'
+        shell: msys2 {0}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 1
+          CC: ${{ matrix.cc }}
+          CGO_LDFLAGS: ${{ matrix.cgo_ldflags }}
+        run: |
+          go build \
+            -trimpath \
+            -tags=cli \
+            -ldflags="-s -w -linkmode external -extldflags '-static' -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
+            -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}.exe" \
             ./cmd/postie/postie.go
 
       # Catch static-linking regressions in CI instead of at user launch time


### PR DESCRIPTION
## Summary

[Dev Build on main](https://github.com/javi11/postie/actions/runs/28683818896/job/85072619510) failed at the "Verify no MinGW runtime DLL dependencies" step (added in #235): `postie-cli-windows-amd64.exe` imported `libstdc++-6.dll` and `libwinpthread-1.dll`. The check is correct — the binary was genuinely broken and would fail to launch on machines without MinGW. This was pre-existing; #235's check just exposed it (the PR workflow never builds the Windows CLI, and the check's own merge run was cancelled by the next push).

**Root cause:** the CLI `go build` ran in plain Git Bash, picking up the runner's pre-installed MinGW GCC instead of the pinned MSYS2 toolchain — so the GCC pin from #234 never applied to the CLI build, and static linking silently regressed to dynamic MinGW runtime imports.

**Fix:** build the Windows CLI inside the MSYS2 shell (`path-type: inherit`) with `CGO_LDFLAGS: '-static-libgcc -static-libstdc++'` — the exact recipe the passing GUI jobs already use. Applied to both `dev-build.yml` and `release.yml` (the release build step is split into non-Windows/Windows variants since `shell:` can't vary per matrix entry).

## Test plan

- [x] Dev Build run on this branch (via a temporary trigger, since removed): [run 28684165697](https://github.com/javi11/postie/actions/runs/28684165697) — all jobs green
- [x] Verify step now reports only system DLLs (`KERNEL32.dll`, `msvcrt.dll`) and prints "OK: no MinGW runtime DLL dependencies found"
- [ ] Release workflow change exercises the same recipe at the next tag