### PR TITLE
fix(ci): build full cmd packages and use native arm64 runner

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -189,7 +189,7 @@ jobs:
             -tags=cli \
             -ldflags="-s -w -linkmode external -extldflags '-static' -X 'main.Version=${{ steps.version.outputs.version }}'" \
             -o "postie-cli-windows-amd64.exe" \
-            ./cmd/postie/postie.go
+            ./cmd/postie
 
       - name: Verify no MinGW runtime DLL dependencies
         uses: ./.github/actions/verify-windows-gui-dlls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,8 @@ jobs:
             cc: ''
           - goos: linux
             goarch: arm64
-            runner: ubuntu-latest
-            cc: 'zig cc -target aarch64-linux-musl'
+            runner: ubuntu-24.04-arm
+            cc: ''
           # macOS builds
           - goos: darwin
             goarch: amd64
@@ -147,13 +147,6 @@ jobs:
             https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-${GCC_VER}-any.pkg.tar.zst
           gcc --version
 
-      # Install Zig for cross-compilation (Linux ARM64)
-      - name: Install Zig
-        if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.1
-
       # Extract version info
       - name: Extract version info
         id: version
@@ -180,7 +173,7 @@ jobs:
             -tags=cli \
             -ldflags="-s -w -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
             -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}" \
-            ./cmd/postie/postie.go
+            ./cmd/postie
 
       # Build inside the MSYS2 shell so the pinned MSYS2 GCC (not the runner's
       # pre-installed MinGW) does the cgo link — its static libs make
@@ -200,7 +193,7 @@ jobs:
             -tags=cli \
             -ldflags="-s -w -linkmode external -extldflags '-static' -X 'main.Version=${{ steps.version.outputs.version }}' -X 'main.GitCommit=${{ steps.version.outputs.commit }}' -X 'main.Timestamp=${{ steps.version.outputs.timestamp }}'" \
             -o "postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}.exe" \
-            ./cmd/postie/postie.go
+            ./cmd/postie
 
       # Catch static-linking regressions in CI instead of at user launch time
       - name: Verify no MinGW runtime DLL dependencies
@@ -386,7 +379,7 @@ jobs:
             -a \
             -ldflags '-linkmode external -extldflags "-static" -s -w -X "main.Version=${{ steps.version.outputs.version }}" -X "main.GitCommit=${{ steps.version.outputs.commit }}" -X "main.Timestamp=${{ steps.version.outputs.timestamp }}"' \
             -o build/postie-web-linux-amd64 \
-            cmd/web/main.go
+            ./cmd/web
         env:
           CC: gcc
 


### PR DESCRIPTION
## Problem

The v0.0.30 release build (run [28684700916](https://github.com/javi11/postie/actions/runs/28684700916)) failed in two jobs:

1. **build-web-linux** — compiled `cmd/web/main.go` as a single file. Once web handlers were split into `arr_handlers.go` and `api_key.go`, that file no longer sees their methods, so the build failed with `ws.handleListArrInstances undefined` (and ~8 similar errors).
2. **build-cli (linux/arm64, zig musl)** — cross-compiled with `zig cc -target aarch64-linux-musl`, but par2go links `-lstdc++` (GNU libstdc++), which zig's musl target does not provide → `ld.lld: undefined symbol: std::thread::join()` and many other `std::` symbols from `libparpar_gf16_linux_arm64.a`.

## Latent bug also fixed

The CLI build compiled `cmd/postie/postie.go` as a single file too. It compiled fine but **silently dropped the `watch` subcommand**, which is registered in `cmd/postie/watch.go` via `init()`. Released CLIs since v0.0.29-rc2 have been missing `postie watch`.

## Fix

- Build the whole packages `./cmd/web` and `./cmd/postie` (all 4 build steps across `release.yml` and `dev-build.yml`) so every file in each package is compiled.
- Switch the linux/arm64 CLI job to the native `ubuntu-24.04-arm` runner — the same runner the already-passing `build-image-arm64` job uses — so system g++/libstdc++ resolves par2go's C++ deps. Removed the now-unused Zig setup step.

## Verification

- `go build ./cmd/web` and `go build -tags=cli ./cmd/postie` succeed locally; the single-file builds reproduce the exact CI errors.
- `postie --help` from the package build lists the `watch` command (absent from the single-file build).
- arm64 native build mirrors the proven `build-image-arm64` path; confirmed green by the CI run on this PR.

## Context

Unblocks the v0.0.30 release (which carries the Windows CLI static-linking fix for #154).