### PR TITLE
feat(servers): allow custom display names for NNTP providers

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,6 +1,7 @@
 # Example configuration for nzb-upload with queue settings
 servers:
-  - host: 'news.example.com'
+  - name: 'Primary Provider' # optional display name shown in the UI instead of "Provider 1"
+    host: 'news.example.com'
     port: 563
     username: 'your_username'
     password: 'your_password'

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -150,7 +150,8 @@ Configure one or more Usenet providers:
 
 ```yaml
 servers:
-  - host: news.example.com # Server hostname
+  - name: "" # Optional display name shown in the UI instead of "Provider N"
+    host: news.example.com # Server hostname
     port: 119 # Server port (typically 119 for non-SSL, 563 for SSL)
     username: user # Your username
     password: pass # Your password

--- a/frontend/src/lib/components/NntpServerManager.svelte
+++ b/frontend/src/lib/components/NntpServerManager.svelte
@@ -364,7 +364,9 @@
             <div class="flex justify-between items-start mb-4">
               <div class="flex items-center gap-2">
                 <h4 class="font-medium text-base-content">
-                  {#if restrictedRole === "upload"}
+                  {#if server.name}
+                    {server.name}
+                  {:else if restrictedRole === "upload"}
                     {$t("settings.server.account_number", {
                       values: { number: index + 1 },
                     })}
@@ -489,7 +491,22 @@
                 </div>
               {/if}
 
-              <!-- Host / Port / SSL -->
+              <!-- Name / Host / Port / SSL -->
+              <div class="md:col-span-2">
+                <label for="name-{index}" class="label">
+                  <span class="label-text">
+                    {$t("settings.server.name")}
+                  </span>
+                </label>
+                <input
+                  id="name-{index}"
+                  class="input input-bordered w-full"
+                  bind:value={localServers[index].name}
+                  placeholder={$t("settings.server.name_placeholder")}
+                  oninput={() => onServerFieldChange(index)}
+                />
+              </div>
+
               <div>
                 <label for="host-{index}" class="label">
                   <span class="label-text">

--- a/frontend/src/lib/components/dashboard/ProviderStatus.svelte
+++ b/frontend/src/lib/components/dashboard/ProviderStatus.svelte
@@ -112,7 +112,7 @@ onDestroy(() => {
 								<StatusIcon class="w-5 h-5 {getProviderStatusClass(provider)}" />
 								<div>
 									<h3 class="font-semibold text-base-content">
-										{provider.host}
+										{provider.name || provider.host}
 									</h3>
 								</div>
 							</div>

--- a/frontend/src/lib/components/settings/ServerSection.svelte
+++ b/frontend/src/lib/components/settings/ServerSection.svelte
@@ -32,6 +32,7 @@ let hasMultipleUploadBackbones = $derived(
 // Helper to build a ServerConfig from a plain object
 function toServerConfig(server: any, role: "upload" | "verify"): configType.ServerConfig {
 	const s = new configType.ServerConfig();
+	s.name = server.name || "";
 	s.enabled = server.enabled ?? true;
 	s.host = server.host || "";
 	s.port = server.port || 119;
@@ -53,6 +54,7 @@ let uploadManagedServers = $derived(
 	(config.servers ?? [])
 		.filter(s => s != null && (s.role || "upload") !== "verify")
 		.map(s => ({
+			name: s.name || "",
 			enabled: s.enabled ?? true,
 			host: s.host || "",
 			port: s.port || 119,
@@ -73,6 +75,7 @@ let verifyManagedServers = $derived(
 	(config.servers ?? [])
 		.filter(s => s != null && s.role === "verify")
 		.map(s => ({
+			name: s.name || "",
 			enabled: s.enabled ?? true,
 			host: s.host || "",
 			port: s.port || 119,

--- a/frontend/src/lib/components/setup/ServerSetupStep.svelte
+++ b/frontend/src/lib/components/setup/ServerSetupStep.svelte
@@ -29,6 +29,7 @@ if (servers.length === 0) {
 
 function toNntpFormat(s: backend.ServerData) {
 	return {
+		name: s.name || "",
 		host: s.host,
 		port: s.port,
 		ssl: s.ssl || false,
@@ -45,6 +46,7 @@ function toNntpFormat(s: backend.ServerData) {
 
 function toServerData(s: any, role: string): backend.ServerData {
 	const sd = new backend.ServerData();
+	sd.name = s.name || "";
 	sd.host = s.host || "";
 	sd.port = s.port || 119;
 	sd.ssl = s.ssl || false;

--- a/frontend/src/lib/locales/en/settings.json
+++ b/frontend/src/lib/locales/en/settings.json
@@ -392,6 +392,8 @@
 			"disabled_description": "This provider will not be used for uploading",
 			"valid": "Valid",
 			"remove": "Remove",
+			"name": "Name",
+			"name_placeholder": "e.g. Primary Provider",
 			"host": "Host",
 			"host_required": "Host *",
 			"host_placeholder": "news.example.com",

--- a/frontend/src/lib/locales/es/settings.json
+++ b/frontend/src/lib/locales/es/settings.json
@@ -429,6 +429,8 @@
 			"enabled_description": "Este proveedor será utilizado para cargas",
 			"disabled_description": "Este proveedor no será utilizado para cargas",
 			"remove": "Eliminar",
+			"name": "Nombre",
+			"name_placeholder": "p. ej. Proveedor Principal",
 			"host": "Host",
 			"host_required": "Host *",
 			"host_placeholder": "news.ejemplo.com",

--- a/frontend/src/lib/locales/fr/settings.json
+++ b/frontend/src/lib/locales/fr/settings.json
@@ -430,6 +430,8 @@
 			"enabled_description": "Ce fournisseur sera utilisé pour les téléchargements",
 			"disabled_description": "Ce fournisseur ne sera pas utilisé pour les téléchargements",
 			"remove": "Supprimer",
+			"name": "Nom",
+			"name_placeholder": "ex. Fournisseur Principal",
 			"host": "Hôte",
 			"host_required": "Hôte *",
 			"host_placeholder": "news.exemple.com",

--- a/frontend/src/lib/locales/tr/settings.json
+++ b/frontend/src/lib/locales/tr/settings.json
@@ -392,6 +392,8 @@
 			"disabled_description": "Bu sağlayıcı yükleme için kullanılmayacak",
 			"valid": "Geçerli",
 			"remove": "Kaldır",
+			"name": "Ad",
+			"name_placeholder": "örn. Birincil Sağlayıcı",
 			"host": "Ana Bilgisayar",
 			"host_required": "Ana Bilgisayar *",
 			"host_placeholder": "news.example.com",

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -67,6 +67,7 @@ export namespace backend {
 	    }
 	}
 	export class NntpProviderMetrics {
+	    name: string;
 	    host: string;
 	    activeConnections: number;
 	    maxConnections: number;
@@ -75,13 +76,14 @@ export namespace backend {
 	    missing: number;
 	    pingRTT: string;
 	    inflight: number;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new NntpProviderMetrics(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
 	        this.host = source["host"];
 	        this.activeConnections = source["activeConnections"];
 	        this.maxConnections = source["maxConnections"];
@@ -322,6 +324,7 @@ export namespace backend {
 	    }
 	}
 	export class ServerData {
+	    name: string;
 	    host: string;
 	    port: number;
 	    username: string;
@@ -329,13 +332,14 @@ export namespace backend {
 	    ssl: boolean;
 	    maxConnections: number;
 	    role: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new ServerData(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
 	        this.host = source["host"];
 	        this.port = source["port"];
 	        this.username = source["username"];
@@ -794,6 +798,7 @@ export namespace config {
 	    }
 	}
 	export class ServerConfig {
+	    name?: string;
 	    host: string;
 	    port: number;
 	    username: string;
@@ -815,6 +820,7 @@ export namespace config {
 	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
 	        this.host = source["host"];
 	        this.port = source["port"];
 	        this.username = source["username"];

--- a/frontend/src/routes/metrics/+page.svelte
+++ b/frontend/src/routes/metrics/+page.svelte
@@ -209,7 +209,7 @@ function formatNumber(num: number): string {
 							{#each metrics.providers as provider}
 								<tr>
 									<td>
-										<div class="font-semibold">{provider.host}</div>
+										<div class="font-semibold">{provider.name || provider.host}</div>
 									</td>
 									<td>
 										<div class="text-sm">

--- a/internal/backend/app.go
+++ b/internal/backend/app.go
@@ -29,6 +29,7 @@ import (
 
 // ServerData represents the server configuration data from the frontend
 type ServerData struct {
+	Name           string `json:"name"`
 	Host           string `json:"host"`
 	Port           int    `json:"port"`
 	Username       string `json:"username"`
@@ -87,6 +88,7 @@ type NntpPoolMetrics struct {
 
 // NntpProviderMetrics represents metrics for individual NNTP providers
 type NntpProviderMetrics struct {
+	Name              string  `json:"name"`
 	Host              string  `json:"host"`
 	ActiveConnections int     `json:"activeConnections"`
 	MaxConnections    int     `json:"maxConnections"`
@@ -934,6 +936,7 @@ func (a *App) SetupWizardComplete(wizardData SetupWizardData) error {
 			role = config.ServerRoleVerify
 		}
 		server := config.ServerConfig{
+			Name:           serverData.Name,
 			Host:           serverData.Host,
 			Port:           serverData.Port,
 			Username:       serverData.Username,
@@ -1170,22 +1173,25 @@ func (a *App) GetNntpPoolMetrics() (NntpPoolMetrics, error) {
 		ProviderErrors:    providerErrors,
 	}
 
-	// Build a map from provider address to inflight config for quick lookup.
+	// Build maps from provider address to config for quick lookup.
 	// Key format matches nntppool's internal provider name: "host:port+username" or "host:port".
+	providerAddrKey := func(host string, port int, username string) string {
+		if username != "" {
+			return fmt.Sprintf("%s:%d+%s", host, port, username)
+		}
+		return fmt.Sprintf("%s:%d", host, port)
+	}
 	inflightByAddr := make(map[string]int)
+	nameByAddr := make(map[string]string)
 	if a.config != nil {
 		for _, srv := range a.config.Servers {
-			var key string
-			if srv.Username != "" {
-				key = fmt.Sprintf("%s:%d+%s", srv.Host, srv.Port, srv.Username)
-			} else {
-				key = fmt.Sprintf("%s:%d", srv.Host, srv.Port)
-			}
+			key := providerAddrKey(srv.Host, srv.Port, srv.Username)
 			inflight := srv.Inflight
 			if inflight <= 0 {
 				inflight = 10
 			}
 			inflightByAddr[key] = inflight
+			nameByAddr[key] = srv.Name
 		}
 	}
 
@@ -1193,6 +1199,7 @@ func (a *App) GetNntpPoolMetrics() (NntpPoolMetrics, error) {
 	providers := make([]NntpProviderMetrics, 0, len(stats.Providers))
 	for _, provider := range stats.Providers {
 		providers = append(providers, NntpProviderMetrics{
+			Name:              nameByAddr[provider.Name],
 			Host:              provider.Name,
 			ActiveConnections: provider.ActiveConnections,
 			MaxConnections:    provider.MaxConnections,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,9 @@ type Par2Config struct {
 
 // ServerConfig represents a Usenet server configuration
 type ServerConfig struct {
+	// Name is an optional custom display label shown in place of the auto-numbered
+	// "Provider N" / "Server N" in the UI. Purely cosmetic — never sent to nntppool.
+	Name                           string `yaml:"name,omitempty" json:"name,omitempty"`
 	Host                           string `yaml:"host" json:"host"`
 	Port                           int    `yaml:"port" json:"port"`
 	Username                       string `yaml:"username" json:"username"`


### PR DESCRIPTION
## Summary

- Adds an optional `Name` field to server/provider configuration so users can label each NNTP provider (e.g. "Astraweb Primary") instead of the auto-numbered "Provider 1, 2, 3..." shown in the setup wizard, settings page, and dashboard/metrics.
- Verified against the current `nntppool` library (pinned v4.11.1, checked up through the latest v4.13.0/`main`): it has **no** `Name` field on `Provider` and only auto-derives an internal name from `host+username` for its own logs/stats. This is therefore a Postie-side config/UI feature only — no dependency bump, and the custom name is never sent to the connection pool.
- Falls back to the existing "Provider N"/host-based display exactly as before when no name is set, so existing configs are unaffected.

Closes #220

## Changes

- **Backend**: `ServerConfig.Name` (`internal/config/config.go`), `ServerData.Name` (`internal/backend/app.go`), `NntpProviderMetrics.Name`; wired through `SetupWizardComplete` and `GetNntpPoolMetrics`'s host→config lookup.
- **Frontend**: new "Name" input + header fallback in `NntpServerManager.svelte` (shared by setup wizard and settings); Wails bindings (`models.ts`); dashboard/metrics display now shows `provider.name || provider.host`; translations added for en/es/fr/tr.
- **Bug fix found during testing**: `ServerSection.svelte` (Settings page) and `ServerSetupStep.svelte` (setup wizard) both rebuild server objects through explicit field whitelists that silently dropped any field not listed. Added `name` to each of these whitelists — otherwise a typed name would render once but be stripped on the next save.
- Minor docs touch: `config-example.yaml`, `docs/docs/configuration.md`.

## Test plan

- [x] `go build ./internal/...` and `go vet ./internal/...`
- [x] `go test ./internal/config/...` (existing suite, no regressions)
- [x] `bun run check` (svelte-check) — 0 errors/warnings
- [x] Manually verified end-to-end in a sandboxed environment (isolated `$HOME`, real Go web server + Vite dev): typed a name in the setup wizard with live header update, confirmed round-trip through YAML → JSON config API, persisted through a Settings-page save, and confirmed it renders on the `/metrics` page's provider table in place of the raw host.
- [ ] Manual smoke test in the packaged Wails desktop app (not run in this environment)